### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Community code of conduct
+
+This code of conduct outlines our expectations for the EDAM community, including the EDAM-browser project. It is based loosely on the former Open Code of Conduct from the TODO Group. We are committed to providing a welcoming and productive community for all and expect our code of conduct to be honored. Our open source community strives to be:
+
+- **Considerate:** You depend upon the work of others who in turn depend on you. You're unlikely to be fully aware of the ramifications of your proposals or actions, and the constraints others work under. Before deciding or acting, talk to others and reach a common understanding of the consequences.
+- **Constructive:** We will not agree all the time. Where we disagree, try to understand why and maintain a positive attitude in seeking a resolution, bearing in mind we share a common goal.
+- **Supportive:** Support others in their work (you depend on them!), respecting the fact that we have different levels of experience and technical ability.
+- **Open-minded:** We have a wide range of backgrounds, skills and perspectives - this diversity is a strength. Be wary of ignoring or misunderstanding another viewpoint in the vindication of your own.
+- **Respectful:** Disagreement and differences do not excuse bad manners. Never allow frustration to turn into aggressive conduct or a personal attack. A happy atmosphere is a productive one: be nice, and keep a sense of humour. If you can't be nice, be quiet.
+- **Tolerant:** Treat people fairly and equally irrespective of their background and identity, including technical ability, experience, education, race, gender, nationality, age *etc*.
+- **Wise:** We are not infallible; we will make mistakes and change our viewpoints: admit and learn from mistakes and allow others to do the same.
+
+## Conflict resolution
+If you experience or witness unacceptable behavior, or have any other concerns, please report it by contacting any member of the CoC committee, currently [Matúš Kalaš (apapronominal)](mailto:matus.kalas@uib.no) and [Hervé Ménager (he/him)](mailto:herve.menager@pasteur.fr). All reports will be handled with discretion.


### PR DESCRIPTION
Essentially copied from https://github.com/edamontology/edamontology/blob/master/CODE_OF_CONDUCT.md

Co-authored-by: @matuskalas <matus.kalas@uib.no>