### PR TITLE
added suitable search box placeholder and ideal search icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,9 +119,13 @@
                             type="text"
                             tabindex="1"
                             class="form-control ui-autocomplete-input search-term"
-                            placeholder="Type at least 2 letters"
+                            placeholder="Search concepts..."
                             onclick="$(this).select();"
                     >
+                    <span class="input-group-text border-0" id="search-addon" >
+                        <i class="glyphicon glyphicon-search form-control-feedback" style="font-size: 15px; color: blue;"></i>
+                      </span>
+                    
                 </div>
             </h1>
         </div>

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                             type="text"
                             tabindex="1"
                             class="form-control ui-autocomplete-input search-term"
-                            placeholder="Search concepts..."
+                            placeholder="Please type at least two letters to search concepts..."
                             onclick="$(this).select();"
                     >
                     <span class="input-group-text border-0" id="search-addon" >


### PR DESCRIPTION

#52 
An ideal search box should have a brief but comprehensive placeholder i.e "Search concepts..." and the magnifying-glass icon should be of the right size . Below is the result of a change I made

![Search box](https://user-images.githubusercontent.com/55056522/112938761-ea495980-9132-11eb-8adb-348f5c529558.png)
  
