### PR TITLE
some might be useful options

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -59,3 +59,11 @@ input:disabled+.text-for-disabled-input{
     word-break: break-all;
     white-space: normal;
 }
+
+.footer-tools {
+    position: relative;
+    right: 2rem;
+    height: 0;
+    text-align: right;
+
+}

--- a/css/index.css
+++ b/css/index.css
@@ -67,3 +67,9 @@ input:disabled+.text-for-disabled-input{
     text-align: right;
 
 }
+
+@media screen and (min-width: 1200px) {
+  a.back-to-top {
+    display: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         </div>
     </div>
 </div>
-<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a class="back-to-top" href="#top" title="Reach the top of the page">Back to top</a> </div>    
+<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs :)" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a class="back-to-top" href="#top" title="Reach the top of the page">Back to top</a> </div>    
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         </div>
     </div>
 </div>
-<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a href="#top" title="Reach the top of the page">Back to top</a> </div>    
+<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a class="back-to-top" href="#top" title="Reach the top of the page">Back to top</a> </div>    
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">

--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
         </div>
     </div>
 </div>
+<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/index.html">Edit this Page</a> &nbsp;<a href="#top" title="Reach the top of the page">Back to top</a> </div>    
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         </div>
     </div>
 </div>
-<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/index.html">Edit this Page</a> &nbsp;<a href="#top" title="Reach the top of the page">Back to top</a> </div>    
+<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs ♥" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a href="#top" title="Reach the top of the page">Back to top</a> </div>    
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         </div>
     </div>
 </div>
-<div class="footer-tools"> <a title="Improve this document, receive free virtual hugs :)" href="https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md">Edit this Page</a> &nbsp;<a class="back-to-top" href="#top" title="Reach the top of the page">Back to top</a> </div>    
+<div class="footer-tools"> <a class="back-to-top" href="#top" title="Reach the top of the page">Back to top</a> </div>    
 <!-- Modal -->
 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
     <div class="modal-dialog" role="document">


### PR DESCRIPTION
![Screenshot from 2021-03-31 02-46-50](https://user-images.githubusercontent.com/45493793/113058313-99397400-91cb-11eb-96cd-a9e92d80a4e5.png)
[Back to top] directs to the top of the page (useful for smaller screens)
Edit this page directs the user to the [Contribution Guide](https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md) if one is willing to contribute.

I added edit this page, because it's no where mentioned on how to contribute (assuming that they don't know about the source repository), if a person who doesn't have so sound knowledge of all the terms used in the browser but still wants to suggest some feature than this might be useful.
Suppose, that person doesn't want to add something like [this](https://edamontology.github.io/edam-browser/edit.html?term=http://edamontology.org/data_2914&branch=data) then they might use it to suggest some bug or other features, or even they can contact the maintainer by this.
