### PR TITLE
Add: filtering autocomplete when adding/editing a term 

### DIFF
--- a/js/autocomplete-edam-reusable.js
+++ b/js/autocomplete-edam-reusable.js
@@ -1,5 +1,3 @@
-var typeDict={"has_topic_container":"topic","is_format_of_container":"data","has_input_container":"data","has_output_container":"data"};
-
 
 function fake_interactive_edam_browser(){
     var identifierToElement={},
@@ -167,8 +165,8 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
 
             //match type with the parent's container id
             var type=typeDict[$(this.element).parent().attr('id')];
-            console.log(type);
-
+            
+            //apply type filter to data
             data=data.filter(function filterCategories(item){
                 var matcher=new RegExp( type+'_', "i" );
                 return matcher.test(item.node.__autocomplete_from_edam_browser);

--- a/js/autocomplete-edam-reusable.js
+++ b/js/autocomplete-edam-reusable.js
@@ -170,10 +170,10 @@ function build_autocomplete_from_edam_browser(edam_browser, elt,dict){
 
             //match type with the parent's container id
             var type=typeDict[$(this.element).parent().attr('id')];
+            var matcher=new RegExp( type+'_', "i" );
             
             //apply type filter to data
             data=data.filter(function filterCategories(item){
-                var matcher=new RegExp( type+'_', "i" );
                 return matcher.test(item.node.__autocomplete_from_edam_browser);
         
             });

--- a/js/autocomplete-edam-reusable.js
+++ b/js/autocomplete-edam-reusable.js
@@ -117,8 +117,9 @@ function fake_interactive_edam_browser(){
 * Build the autocomplete from the edam browser.
 * @param {object} the edam browser instance
 * @param {str} the target where we should build the autocomplete
+* @param {object} the filter dictionary (if a filter is applied)
 */
-function build_autocomplete_from_edam_browser(edam_browser, elt){
+function build_autocomplete_from_edam_browser(edam_browser, elt,dict){
     if(typeof elt == "undefined"){
         elt='.search-term';
     }
@@ -163,6 +164,10 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
                 }
             );
 
+            //if a filter dictionary is applied
+            if (dict)
+            {
+
             //match type with the parent's container id
             var type=typeDict[$(this.element).parent().attr('id')];
             
@@ -172,6 +177,8 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
                 return matcher.test(item.node.__autocomplete_from_edam_browser);
         
             });
+
+            }
 
             response(data);
         },

--- a/js/autocomplete-edam-reusable.js
+++ b/js/autocomplete-edam-reusable.js
@@ -1,3 +1,6 @@
+var typeDict={"has_topic_container":"topic","is_format_of_container":"data","has_input_container":"data","has_output_container":"data"};
+
+
 function fake_interactive_edam_browser(){
     var identifierToElement={},
         identifierAccessor = function (d) {
@@ -144,6 +147,7 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
       return '<span class="matched">'+match+'</span>';
     }
 
+
     $(elt).autocomplete({
         source : function (request, response) {
             var data=[];
@@ -160,6 +164,17 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
                     data.push({value:edam_browser.textAccessor(elt),node:elt});
                 }
             );
+
+            //match type with the parent's container id
+            var type=typeDict[$(this.element).parent().attr('id')];
+            console.log(type);
+
+            data=data.filter(function filterCategories(item){
+                var matcher=new RegExp( type+'_', "i" );
+                return matcher.test(item.node.__autocomplete_from_edam_browser);
+        
+            });
+
             response(data);
         },
         minLength: 2,
@@ -175,7 +190,7 @@ function build_autocomplete_from_edam_browser(edam_browser, elt){
             for (i=0;i<ui.content.length;i++){
                 ui.content[i].lev = window.Levenshtein(ui.content[i].label.toUpperCase(),searched);
                                   //+ window.Levenshtein(ui.content[i].node.__autocomplete_from_edam_browser,searched) / 5;
-            }
+                                }
             ui.content.sort(function(a, b) {
               return a.lev - b.lev;
             });

--- a/js/edit.js
+++ b/js/edit.js
@@ -4,7 +4,7 @@ var typeDict={"has_topic_container":"topic","is_format_of_container":"data","has
 
 function fill_form(identifier, parent, branch){
     tree_file = getTreeFile(branch);
-    build_autocomplete_from_edam_browser(browser);
+    build_autocomplete_from_edam_browser(browser,undefined,typeDict);
     browser.interactive_tree.cmd.getElementByIdentifier(identifier);
  
     build_form(
@@ -85,7 +85,7 @@ function addTermField(container, kind, initial_term){
 //    build_autocomplete(
 //        getTreeFile(getCookie("edam_browser_branch","topic")),
     build_autocomplete_from_edam_browser(browser,
-        ".search-term[name="+kind+"-"+i+"]"
+        ".search-term[name="+kind+"-"+i+"]",typeDict
     );
 }
 

--- a/js/edit.js
+++ b/js/edit.js
@@ -103,7 +103,7 @@ window.onload = function() {
     var sub_branch = getUrlParameter('term')+getUrlParameter('parent');
     sub_branch = sub_branch.substring(sub_branch.lastIndexOf('/')+1, sub_branch.lastIndexOf('_'));
     $('#pageTitle .branch').text(sub_branch);
-    typeDict['parent_container']=sub_branch;
+    typeDict.parent_container=sub_branch;
     browser = fake_interactive_edam_browser();
 
     browser.interactive_tree.loadingDoneHandler(function(){

--- a/js/edit.js
+++ b/js/edit.js
@@ -1,9 +1,12 @@
 var browser;
 
+var typeDict={"has_topic_container":"topic","is_format_of_container":"data","has_input_container":"data","has_output_container":"data"};
+
 function fill_form(identifier, parent, branch){
     tree_file = getTreeFile(branch);
     build_autocomplete_from_edam_browser(browser);
     browser.interactive_tree.cmd.getElementByIdentifier(identifier);
+ 
     build_form(
         browser.interactive_tree.cmd.getElementByIdentifier(identifier),
         browser.interactive_tree.cmd.getElementByIdentifier(parent)
@@ -100,7 +103,9 @@ window.onload = function() {
     var sub_branch = getUrlParameter('term')+getUrlParameter('parent');
     sub_branch = sub_branch.substring(sub_branch.lastIndexOf('/')+1, sub_branch.lastIndexOf('_'));
     $('#pageTitle .branch').text(sub_branch);
+    typeDict['parent_container']=sub_branch;
     browser = fake_interactive_edam_browser();
+
     browser.interactive_tree.loadingDoneHandler(function(){
         fill_form(uri, getUrlParameter('parent'), branch);
     });


### PR DESCRIPTION
**Issue:** #48 
**checklist:**
- [x]  same type for the Parent
- [x]  topic for has topic
- [x]  data for is format of
- [x]  data for has input
- [x]  data for has output

I tried to make it as optional as possible (to not break the main search). 
But I was confused about how reusable the autocomplete is? If it will apply to other ontologies in the future or will need different filtering options? In which cases, this may not hold and a separate component may be needed.

But for now it works and nothing is broken!

**Before** 
![beforeFilter](https://user-images.githubusercontent.com/37930475/113146978-9b81e980-9230-11eb-821e-89946cce48f9.gif)

**After**
![afterFilter](https://user-images.githubusercontent.com/37930475/113147006-a472bb00-9230-11eb-8e32-8ee2c0f597ab.gif)

**Home Search After**
![mainSearch](https://user-images.githubusercontent.com/37930475/113147058-afc5e680-9230-11eb-89a6-56b456dcf880.gif)

