### PR TITLE
fix configurations in travis.yml to accept code written in ES6 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
- - "node"
+- "10"
 script:
   - npm test


### PR DESCRIPTION
The reason why ES6 code was not accepted earlier is because node was set to accept code written in ES5 and below. I updated the node version in .travis.yml so as to accept code written in ES6

#57 