### PR TITLE
Useful PR Template

### DIFF
--- a/PR_template.md
+++ b/PR_template.md
@@ -1,0 +1,9 @@
+<!--
+Thank you for your pull request!
+
+-->
+
+PR Checklist:
+
+- [ ] Note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
+- [ ] Put any other relevant information below

--- a/PR_template.md
+++ b/PR_template.md
@@ -1,6 +1,5 @@
 <!--
 Thank you for your pull request!
-
 -->
 
 PR Checklist:

--- a/PR_template.md
+++ b/PR_template.md
@@ -5,5 +5,5 @@ Thank you for your pull request!
 
 PR Checklist:
 
-- [ ] Note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
-- [ ] Put any other relevant information below
+- [x] Note any issues closed by this PR with [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
+- [x] Put any other relevant information below


### PR DESCRIPTION
Short and precise PR template is needed (at least important for the first time contributors) so that issues can be linked with the PR directly, helpful for direct status update of an issue related to that PR, which will then prevent replication of work by different users.