### PR TITLE
Enhancement and repositioning of tree controls 

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -88,8 +88,13 @@ a:before {
     text-decoration: none;
 }
 
-.tree-controls {
-    position: absolute;right:0px;
+#tree-and-controls
+{
+    position:relative;
+}
+
+#tree-controls {
+    position: absolute ;right:0px;top:0px;
 }
 
 body {

--- a/css/index.css
+++ b/css/index.css
@@ -94,7 +94,11 @@ a:before {
 }
 
 #tree-controls {
-    position: absolute ;right:0px;top:0px;
+    position: absolute ;
+    right:0px;
+    top:0px;
+    padding: 1em 1em;
+
 }
 
 body {

--- a/css/index.css
+++ b/css/index.css
@@ -88,6 +88,10 @@ a:before {
     text-decoration: none;
 }
 
+.tree-controls {
+    position: absolute;right:0px;
+}
+
 body {
   overflow-x: hidden;
 }

--- a/index.html
+++ b/index.html
@@ -136,25 +136,21 @@
     <div class="content row" id="main">
         <div class="col-xs-12 col-lg-8">
             <div class="panel panel-default">
+                <div id="tree-controls">
+                    <button type="button" class="btn btn-default"
+                    onclick="browser.interactive_tree().cmd().collapseNotSelectedElement()">Collapse not selected elements
+                    </button>
+                    <button type="button" class="btn btn-default"
+                    onclick="browser.interactive_tree().cmd().resetPanAndZoom()">Reset zoom
+                    </button>
+                    <button type="button" class="btn btn-default"
+                    onclick="browser.interactive_tree().cmd().expandAllDescendantElement()">Expand all tree
+                    </button>
+   
+                </div>
                 <div id="tree" class="d3js-tree-container"></div>
             </div>
-            <button type="button" class="btn btn-default"
-                    onclick="browser.interactive_tree().cmd().collapseNotSelectedElement()">Collapse not selected elements
-            </button>
-            <button type="button" class="btn btn-default"
-                    onclick="browser.interactive_tree().cmd().resetPanAndZoom()">Reset zoom
-            </button>
-            <div class="btn-group dropup">
-                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
-                        aria-haspopup="true" aria-expanded="false">
-                    <i class="fa fa-plus"></i>
-                </button>
-                <ul class="dropdown-menu">
-                    <li><a href="#" onclick="browser.interactive_tree().cmd().expandAllDescendantElement()">Expand all tree</a></li>
-                    <!--<li role="separator" class="divider"></li>-->
-                    <!--<li><a href="#">Separated link</a></li>-->
-                </ul>
-            </div>
+            
             <div class="pull-right">
                 <dl class="dl-horizontal meta-info">
                     <dt>Current version</dt>

--- a/index.html
+++ b/index.html
@@ -146,6 +146,12 @@
                     <button type="button" class="btn btn-default"
                     onclick="browser.interactive_tree().cmd().expandAllDescendantElement()">Expand all tree
                     </button>
+                    <button type="button" class="btn btn-default"
+                    onclick="browser.interactive_tree().cmd().manualZoomInAndOut('in')">+
+                    </button>
+                    <button type="button" class="btn btn-default"
+                    onclick="browser.interactive_tree().cmd().manualZoomInAndOut('out')">-
+                    </button>
    
                 </div>
                 <div id="tree" class="d3js-tree-container"></div>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,10 @@
     </div>
     <div class="content row" id="main">
         <div class="col-xs-12 col-lg-8">
-            <div class="panel panel-default">
+            <div class="panel panel-default" id="tree-and-controls">
+    
+                <div id="tree" class="d3js-tree-container"></div>
+
                 <div id="tree-controls">
                     <button type="button" class="btn btn-default"
                     onclick="browser.interactive_tree().cmd().collapseNotSelectedElement()">Collapse not selected elements
@@ -154,7 +157,6 @@
                     </button>
    
                 </div>
-                <div id="tree" class="d3js-tree-container"></div>
             </div>
             
             <div class="pull-right">

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -56,6 +56,7 @@ function interactive_tree() {
         maxX,
         maxY,
         reset,
+        manualZoom,
         id=0,
         identifierToElement={};
 
@@ -110,6 +111,16 @@ function interactive_tree() {
                     shift=margin.left;
                 var t = d3.zoomIdentity.translate(shift,$(target_selector).height()/2).scale(1);
                 svg.call(zoom.transform, t);
+            };
+
+            manualZoom = function(type){
+                if(type=='in'){
+                    zoom.scaleBy(svg, 2);                
+                }
+                else if (type=='out'){
+                    zoom.scaleBy(svg, 0.5);                
+                }
+
             };
 
             update = function (source) {
@@ -678,6 +689,16 @@ function interactive_tree() {
      */
     cmd.resetPanAndZoom = function (){
         reset();
+        return cmd;
+    };
+
+    /**
+     * Zooming in and out with buttons
+     * @param {string} type Zooming type (in or out)
+     * @return cmd() itself
+     */
+    cmd.manualZoomInAndOut = function (type){
+        manualZoom(type);
         return cmd;
     };
 


### PR DESCRIPTION
**Related to issue:**  #68 

**Before:** 

![oldControls](https://user-images.githubusercontent.com/37930475/113712007-e5ae1380-96e5-11eb-9fcf-f1a96dfe9487.PNG)


**After:**
![controls](https://user-images.githubusercontent.com/37930475/113713218-599ceb80-96e7-11eb-996a-03cc9e64b16f.gif)


**Solution Description:**
1. Added +,- zooming buttons to support touchpads with no zooming functionality.
2. Repositioned the controls to overlay the tree as discussed in the referenced issue.

**Further Recommendation:** 
To optimize the UI more, buttons should have shorter labels or, even better, icons representing the functionalities. (refer to https://github.com/edamontology/edam-browser/issues/68#issuecomment-811773060 for a good example of that)
This is however a big jump in the current UI design so it should be addressed in another issue.