### PR TITLE
fix bioportal link

### DIFF
--- a/js/tree-edam-stand-alone.js
+++ b/js/tree-edam-stand-alone.js
@@ -341,7 +341,7 @@ function interactive_edam_browser(){
             "Open in "+
             "<a target=\"_blank\" href=\"http://aber-owl.net/ontology/EDAM/#/Browse/%3Chttp%3A%2F%2Fedamontology.org%2F"+identifier+"%3E\">AberOWL</a>"+
             ", "+
-            "<a target=\"_blank\" href=\"http://bioportal.bioontology.org/ontologies/EDAM/?p=classes&conceptid=http%3A%2F%2Fedamontology.org%2F"+identifier+"\">BioPortal</a>"+
+            "<a target=\"_blank\" href=\"http://bioportal.bioontology.org/ontologies/EDAM/?p=classes&conceptid="+uri+"\">BioPortal</a>"+
             ", "+
             "<a target=\"_blank\" href=\"https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2F"+identifier+"\">OLS</a>"+
             " or "+


### PR DESCRIPTION
I have changed the code to fix the bioportal link by removing the HTML encoding and keeping the url parameter as (http://edamontology.org/format_3620) as suggested by @bryan-brancotte in issue #44. Please let me know if this change is good. The bioportal now links to (https://bioportal.bioontology.org/ontologies/EDAM/?p=classes&conceptid=http://edamontology.org/format_3620).