### PR TITLE
adding padding to the logos

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -77,6 +77,7 @@ input:disabled+.text-for-disabled-input{
     position: absolute;
     left: 50%;
     color: #33CAFF;
+    padding-bottom: 8px;
 }
 
 a:before {


### PR DESCRIPTION
Before:
![Screenshot from 2021-04-13 10-12-36](https://user-images.githubusercontent.com/45493793/114498060-070c8380-9c41-11eb-882a-423d8b5a0645.png)

After:
![Screenshot from 2021-04-13 10-12-20](https://user-images.githubusercontent.com/45493793/114498072-0d026480-9c41-11eb-9166-455c6912ecc7.png)

Adding little padding enhances its look. I missed it initially.