### PR TITLE
Changing tree box size to 60vh for smaller screens

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -51,8 +51,14 @@ input:disabled+.text-for-disabled-input{
     margin-bottom:0px;
     line-height:2;
 }
-#tree {
+@media only screen and (min-width: 600px) {
+  #tree {
     height:70vh;
+  }
+}
+
+#tree {
+    height:60vh;
 }
 
 #edamAccordion table .details td a{


### PR DESCRIPTION
for screens of width less than 600px, changing the vertical height of the tree box will be useful in scrolling.
It doesn't effect viewing the tree branches in the tree box cause that be easily zoomed in phone. but this will solve the scrollability problem to some extent at least.