### PR TITLE
[WIP] Fixing the tree cropping when zooming  

### DIFF
--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -132,7 +132,7 @@ function interactive_tree() {
                 maxY=svgBox.height+svgBox.y;
                 updateWithoutPanAndZoomTuning(source);
                 var xShift=(maxX-minX)/2;
-                zoom.translateExtent([[minX-xShift,minY-yShift], [maxX+xShift,maxY+yShift]]);
+                zoom.translateExtent([[minX-xShift,minY-xShift], [maxX+xShift,maxY+xShift]]);
             };
 
             updateWithoutPanAndZoomTuning = function (source) {

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -124,13 +124,15 @@ function interactive_tree() {
             };
 
             update = function (source) {
-                minX=null;
-                minY=null;
-                maxX=null;
-                maxY=null;
+                //getting the box surronding the svg element ()
+                var svgBox=vis.node().getBBox();
+                minX=svgBox.x;
+                minY=svgBox.y;
+                maxX=svgBox.width+svgBox.x;
+                maxY=svgBox.height+svgBox.y;
                 updateWithoutPanAndZoomTuning(source);
                 var xShift=(maxX-minX)/2;
-                zoom.translateExtent([[minX-xShift,minY-xShift], [maxX+xShift/2,maxY+xShift]]);
+                zoom.translateExtent([[minX-xShift,minY-yShift], [maxX+xShift,maxY+yShift]]);
             };
 
             updateWithoutPanAndZoomTuning = function (source) {


### PR DESCRIPTION
**Issue:** #79 

**Before:**

I believe there were essentially 2 problems:
1. The zoomTranslate coordinates were set and updated when selecting a node only (So, when we just zoom, movement is nearly banned)


![p1Before](https://user-images.githubusercontent.com/37930475/114574304-6dad9380-9c79-11eb-8eaf-c8acdafbce5d.gif)

2.  the shift margin for the maxX was set to half, so the text on the right gets slightly cropped (even after solving 1)


![p2Before](https://user-images.githubusercontent.com/37930475/114576617-9767ba00-9c7b-11eb-9e6a-6b8f1068690e.gif)


**Solution Description:**

1. For 1, I set the zoom translation constraints to be the box surrounding the SVG.
2. For 2, made the margin consistent for all coordinates.


**After:**

1.
![p1After](https://user-images.githubusercontent.com/37930475/114576937-e281cd00-9c7b-11eb-9132-9a94b9b26c30.gif)


2. 

![p2After](https://user-images.githubusercontent.com/37930475/114577113-09d89a00-9c7c-11eb-8ed5-b468babc6f2b.gif)

