### PR TITLE
add start script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Bryan Brancotte",
   "version": "1.0.0",
   "scripts": {
+    "start": "sh start_edam_stand_alone_browser.sh",
     "test": "jshint js/*js"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi @bryan-brancotte @hmenager .
As suggested in issue #121 , this pull request adds a start script to package.json.So, contributors can simply run `yarn start` or `npm start` to start the EDAM browser locally