### PR TITLE
WIP change cursor to hand cursor when hovering over the tree and grabbing cursor when dragging the tree

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -53,7 +53,10 @@ input:disabled+.text-for-disabled-input{
 }
 #tree {
     height:70vh;
+    cursor: grab;
 }
+
+
 
 #edamAccordion table .details td a{
     word-break: break-all;

--- a/node_modules/d3-dispatch/LICENSE
+++ b/node_modules/d3-dispatch/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2010-2016 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/d3-dispatch/README.md
+++ b/node_modules/d3-dispatch/README.md
@@ -1,0 +1,82 @@
+# d3-dispatch
+
+Dispatching is a convenient mechanism for separating concerns with loosely-coupled code: register named callbacks and then call them with arbitrary arguments. A variety of D3 components, such as [d3-request](https://github.com/d3/d3-request), use this mechanism to emit events to listeners. Think of this like Node’s [EventEmitter](https://nodejs.org/api/events.html), except every listener has a well-defined name so it’s easy to remove or replace them.
+
+For example, to create a dispatch for *start* and *end* events:
+
+```js
+var dispatch = d3.dispatch("start", "end");
+```
+
+You can then register callbacks for these events using [*dispatch*.on](#dispatch_on):
+
+```js
+dispatch.on("start", callback1);
+dispatch.on("start.foo", callback2);
+dispatch.on("end", callback3);
+```
+
+Then, you can invoke all the *start* callbacks using [*dispatch*.call](#dispatch_call) or [*dispatch*.apply](#dispatch_apply):
+
+```js
+dispatch.call("start");
+```
+
+Like *function*.call, you may also specify the `this` context and any arguments:
+
+```js
+dispatch.call("start", {about: "I am a context object"}, "I am an argument");
+```
+
+Want a more involved example? See how to use [d3-dispatch for coordinated views](http://bl.ocks.org/mbostock/5872848).
+
+## Installing
+
+If you use NPM, `npm install d3-dispatch`. Otherwise, download the [latest release](https://github.com/d3/d3-dispatch/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-dispatch.v1.min.js) or as part of [D3](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+
+```html
+<script src="https://d3js.org/d3-dispatch.v1.min.js"></script>
+<script>
+
+var dispatch = d3.dispatch("start", "end");
+
+</script>
+```
+
+[Try d3-dispatch in your browser.](https://observablehq.com/collection/@d3/d3-dispatch)
+
+## API Reference
+
+<a name="dispatch" href="#dispatch">#</a> d3.<b>dispatch</b>(<i>types…</i>) · [Source](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js)
+
+Creates a new dispatch for the specified event *types*. Each *type* is a string, such as `"start"` or `"end"`.
+
+<a name="dispatch_on" href="#dispatch_on">#</a> *dispatch*.<b>on</b>(<i>typenames</i>[, <i>callback</i>]) · [Source](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js)
+
+Adds, removes or gets the *callback* for the specified *typenames*. If a *callback* function is specified, it is registered for the specified (fully-qualified) *typenames*. If a callback was already registered for the given *typenames*, the existing callback is removed before the new callback is added.
+
+The specified *typenames* is a string, such as `start` or `end.foo`. The type may be optionally followed by a period (`.`) and a name; the optional name allows multiple callbacks to be registered to receive events of the same type, such as `start.foo` and `start.bar`. To specify multiple typenames, separate typenames with spaces, such as `start end` or `start.foo start.bar`.
+
+To remove all callbacks for a given name `foo`, say `dispatch.on(".foo", null)`.
+
+If *callback* is not specified, returns the current callback for the specified *typenames*, if any. If multiple typenames are specified, the first matching callback is returned.
+
+<a name="dispatch_copy" href="#dispatch_copy">#</a> *dispatch*.<b>copy</b>() · [Source](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js)
+
+Returns a copy of this dispatch object. Changes to this dispatch do not affect the returned copy and <i>vice versa</i>.
+
+<a name="dispatch_call" href="#dispatch_call">#</a> *dispatch*.<b>call</b>(<i>type</i>[, <i>that</i>[, <i>arguments…</i>]]) · [Source](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js)
+
+Like [*function*.call](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), invokes each registered callback for the specified *type*, passing the callback the specified *arguments*, with *that* as the `this` context. See [*dispatch*.apply](#dispatch_apply) for more information.
+
+<a name="dispatch_apply" href="#dispatch_apply">#</a> *dispatch*.<b>apply</b>(<i>type</i>[, <i>that</i>[, <i>arguments</i>]]) · [Source](https://github.com/d3/d3-dispatch/blob/master/src/dispatch.js)
+
+Like [*function*.apply](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), invokes each registered callback for the specified *type*, passing the callback the specified *arguments*, with *that* as the `this` context. For example, if you wanted to dispatch your *custom* callbacks after handling a native *click* event, while preserving the current `this` context and arguments, you could say:
+
+```js
+selection.on("click", function() {
+  dispatch.apply("custom", this, arguments);
+});
+```
+
+You can pass whatever arguments you want to callbacks; most commonly, you might create an object that represents an event, or pass the current datum (*d*) and index (*i*). See [function.call](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Call) and [function.apply](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Apply) for further information.

--- a/node_modules/d3-dispatch/package.json
+++ b/node_modules/d3-dispatch/package.json
@@ -1,0 +1,74 @@
+{
+  "_args": [
+    [
+      "d3-dispatch@2.0.0",
+      "/Users/Kelly/Downloads/edamontology/edam-browser"
+    ]
+  ],
+  "_from": "d3-dispatch@2.0.0",
+  "_id": "d3-dispatch@2.0.0",
+  "_inBundle": false,
+  "_integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+  "_location": "/d3-dispatch",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "d3-dispatch@2.0.0",
+    "name": "d3-dispatch",
+    "escapedName": "d3-dispatch",
+    "rawSpec": "2.0.0",
+    "saveSpec": null,
+    "fetchSpec": "2.0.0"
+  },
+  "_requiredBy": [
+    "/d3-drag"
+  ],
+  "_resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+  "_spec": "2.0.0",
+  "_where": "/Users/Kelly/Downloads/edamontology/edam-browser",
+  "author": {
+    "name": "Mike Bostock",
+    "url": "http://bost.ocks.org/mike"
+  },
+  "bugs": {
+    "url": "https://github.com/d3/d3-dispatch/issues"
+  },
+  "description": "Register named callbacks and call them with arguments.",
+  "devDependencies": {
+    "eslint": "6",
+    "rollup": "1",
+    "rollup-plugin-terser": "5",
+    "tape": "4"
+  },
+  "files": [
+    "dist/**/*.js",
+    "src/**/*.js"
+  ],
+  "homepage": "https://d3js.org/d3-dispatch/",
+  "jsdelivr": "dist/d3-dispatch.min.js",
+  "keywords": [
+    "d3",
+    "d3-module",
+    "event",
+    "listener",
+    "dispatch"
+  ],
+  "license": "BSD-3-Clause",
+  "main": "dist/d3-dispatch.js",
+  "module": "src/index.js",
+  "name": "d3-dispatch",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/d3/d3-dispatch.git"
+  },
+  "scripts": {
+    "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../${npm_package_name}/dist/${npm_package_name}.js ${npm_package_name}.v${npm_package_version%%.*}.js && cp ../${npm_package_name}/dist/${npm_package_name}.min.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git add ${npm_package_name}.v${npm_package_version%%.*}.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git commit -m \"${npm_package_name} ${npm_package_version}\" && git push && cd - && zip -j dist/${npm_package_name}.zip -- LICENSE README.md dist/${npm_package_name}.js dist/${npm_package_name}.min.js",
+    "prepublishOnly": "rm -rf dist && yarn test",
+    "pretest": "rollup -c",
+    "test": "tape 'test/**/*-test.js' && eslint src test"
+  },
+  "sideEffects": false,
+  "unpkg": "dist/d3-dispatch.min.js",
+  "version": "2.0.0"
+}

--- a/node_modules/d3-dispatch/src/dispatch.js
+++ b/node_modules/d3-dispatch/src/dispatch.js
@@ -1,0 +1,84 @@
+var noop = {value: () => {}};
+
+function dispatch() {
+  for (var i = 0, n = arguments.length, _ = {}, t; i < n; ++i) {
+    if (!(t = arguments[i] + "") || (t in _) || /[\s.]/.test(t)) throw new Error("illegal type: " + t);
+    _[t] = [];
+  }
+  return new Dispatch(_);
+}
+
+function Dispatch(_) {
+  this._ = _;
+}
+
+function parseTypenames(typenames, types) {
+  return typenames.trim().split(/^|\s+/).map(function(t) {
+    var name = "", i = t.indexOf(".");
+    if (i >= 0) name = t.slice(i + 1), t = t.slice(0, i);
+    if (t && !types.hasOwnProperty(t)) throw new Error("unknown type: " + t);
+    return {type: t, name: name};
+  });
+}
+
+Dispatch.prototype = dispatch.prototype = {
+  constructor: Dispatch,
+  on: function(typename, callback) {
+    var _ = this._,
+        T = parseTypenames(typename + "", _),
+        t,
+        i = -1,
+        n = T.length;
+
+    // If no callback was specified, return the callback of the given type and name.
+    if (arguments.length < 2) {
+      while (++i < n) if ((t = (typename = T[i]).type) && (t = get(_[t], typename.name))) return t;
+      return;
+    }
+
+    // If a type was specified, set the callback for the given type and name.
+    // Otherwise, if a null callback was specified, remove callbacks of the given name.
+    if (callback != null && typeof callback !== "function") throw new Error("invalid callback: " + callback);
+    while (++i < n) {
+      if (t = (typename = T[i]).type) _[t] = set(_[t], typename.name, callback);
+      else if (callback == null) for (t in _) _[t] = set(_[t], typename.name, null);
+    }
+
+    return this;
+  },
+  copy: function() {
+    var copy = {}, _ = this._;
+    for (var t in _) copy[t] = _[t].slice();
+    return new Dispatch(copy);
+  },
+  call: function(type, that) {
+    if ((n = arguments.length - 2) > 0) for (var args = new Array(n), i = 0, n, t; i < n; ++i) args[i] = arguments[i + 2];
+    if (!this._.hasOwnProperty(type)) throw new Error("unknown type: " + type);
+    for (t = this._[type], i = 0, n = t.length; i < n; ++i) t[i].value.apply(that, args);
+  },
+  apply: function(type, that, args) {
+    if (!this._.hasOwnProperty(type)) throw new Error("unknown type: " + type);
+    for (var t = this._[type], i = 0, n = t.length; i < n; ++i) t[i].value.apply(that, args);
+  }
+};
+
+function get(type, name) {
+  for (var i = 0, n = type.length, c; i < n; ++i) {
+    if ((c = type[i]).name === name) {
+      return c.value;
+    }
+  }
+}
+
+function set(type, name, callback) {
+  for (var i = 0, n = type.length; i < n; ++i) {
+    if (type[i].name === name) {
+      type[i] = noop, type = type.slice(0, i).concat(type.slice(i + 1));
+      break;
+    }
+  }
+  if (callback != null) type.push({name: name, value: callback});
+  return type;
+}
+
+export default dispatch;

--- a/node_modules/d3-dispatch/src/index.js
+++ b/node_modules/d3-dispatch/src/index.js
@@ -1,0 +1,1 @@
+export {default as dispatch} from "./dispatch.js";

--- a/node_modules/d3-drag/LICENSE
+++ b/node_modules/d3-drag/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2010-2016 Mike Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of contributors may be used to
+  endorse or promote products derived from this software without specific prior
+  written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/d3-drag/README.md
+++ b/node_modules/d3-drag/README.md
@@ -1,0 +1,236 @@
+# d3-drag
+
+[Drag-and-drop](https://en.wikipedia.org/wiki/Drag_and_drop) is a popular and easy-to-learn pointing gesture: move the pointer to an object, press and hold to grab it, “drag” the object to a new location, and release to “drop”. D3’s [drag behavior](#api-reference) provides a convenient but flexible abstraction for enabling drag-and-drop interaction on [selections](https://github.com/d3/d3-selection). For example, you can use d3-drag to facilitate interaction with a [force-directed graph](https://github.com/d3/d3-force), or a simulation of colliding circles:
+
+[<img alt="Force-Directed Graph" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/force-graph.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-graph)[<img alt="Force Dragging II" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/force-collide.png" width="420" height="219">](https://observablehq.com/d/c55a5839a5bb7c73)
+
+You can also use d3-drag to implement custom user interface elements, such as a slider. But the drag behavior isn’t just for moving elements around; there are a variety of ways to respond to a drag gesture. For example, you can use it to lasso elements in a scatterplot, or to paint lines on a canvas:
+
+[<img alt="Line Drawing" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/drawing.png" width="420" height="219">](https://observablehq.com/@d3/draw-me)
+
+The drag behavior can be combined with other behaviors, such as [d3-zoom](https://github.com/d3/d3-zoom) for zooming.
+
+[<img alt="Drag & Zoom II" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/dots.png" width="420" height="219">](https://observablehq.com/@d3/drag-zoom)
+
+The drag behavior is agnostic about the DOM, so you can use it with SVG, HTML or even Canvas! And you can extend it with advanced selection techniques, such as a Voronoi overlay or a closest-target search:
+
+[<img alt="Circle Dragging IV" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/voronoi.png" width="420" height="219">](https://observablehq.com/@d3/circle-dragging-iii)[<img alt="Circle Dragging II" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/canvas.png" width="420" height="219">](https://observablehq.com/@d3/circle-dragging-ii)
+
+Best of all, the drag behavior automatically unifies mouse and touch input, and avoids browser idiosyncrasies. When [Pointer Events](https://www.w3.org/TR/pointerevents/) are more widely available, the drag behavior will support those, too.
+
+## Installing
+
+If you use NPM, `npm install d3-drag`. Otherwise, download the [latest release](https://github.com/d3/d3-drag/releases/latest). You can also load directly from [d3js.org](https://d3js.org), either as a [standalone library](https://d3js.org/d3-drag.v2.min.js) or as part of [D3](https://github.com/d3/d3). AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+
+```html
+<script src="https://d3js.org/d3-dispatch.v2.min.js"></script>
+<script src="https://d3js.org/d3-selection.v2.min.js"></script>
+<script src="https://d3js.org/d3-drag.v2.min.js"></script>
+<script>
+
+var drag = d3.drag();
+
+</script>
+```
+
+[Try d3-drag in your browser.](https://observablehq.com/collection/@d3/d3-drag)
+
+## API Reference
+
+This table describes how the drag behavior interprets native events:
+
+| Event        | Listening Element | Drag Event | Default Prevented? |
+| ------------ | ----------------- | ---------- | ------------------ |
+| mousedown⁵   | selection         | start      | no¹                |
+| mousemove²   | window¹           | drag       | yes                |
+| mouseup²     | window¹           | end        | yes                |
+| dragstart²   | window            | -          | yes                |
+| selectstart² | window            | -          | yes                |
+| click³       | window            | -          | yes                |
+| touchstart   | selection         | start      | no⁴                |
+| touchmove    | selection         | drag       | yes                |
+| touchend     | selection         | end        | no⁴                |
+| touchcancel  | selection         | end        | no⁴                |
+
+The propagation of all consumed events is [immediately stopped](https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation). If you want to prevent some events from initiating a drag gesture, use [*drag*.filter](#drag_filter).
+
+¹ Necessary to capture events outside an iframe; see [#9](https://github.com/d3/d3-drag/issues/9).
+<br>² Only applies during an active, mouse-based gesture; see [#9](https://github.com/d3/d3-drag/issues/9).
+<br>³ Only applies immediately after some mouse-based gestures; see [*drag*.clickDistance](#drag_clickDistance).
+<br>⁴ Necessary to allow [click emulation](https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW7) on touch input; see [#9](https://github.com/d3/d3-drag/issues/9).
+<br>⁵ Ignored if within 500ms of a touch gesture ending; assumes [click emulation](https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html#//apple_ref/doc/uid/TP40006511-SW7).
+
+<a href="#drag" name="drag">#</a> d3.<b>drag</b>() · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/collection/@d3/d3-drag)
+
+Creates a new drag behavior. The returned behavior, [*drag*](#_drag), is both an object and a function, and is typically applied to selected elements via [*selection*.call](https://github.com/d3/d3-selection#selection_call).
+
+<a href="#_drag" name="_drag">#</a> <i>drag</i>(<i>selection</i>) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/collection/@d3/d3-drag)
+
+Applies this drag behavior to the specified [*selection*](https://github.com/d3/d3-selection). This function is typically not invoked directly, and is instead invoked via [*selection*.call](https://github.com/d3/d3-selection#selection_call). For example, to instantiate a drag behavior and apply it to a selection:
+
+```js
+d3.selectAll(".node").call(d3.drag().on("start", started));
+```
+
+Internally, the drag behavior uses [*selection*.on](https://github.com/d3/d3-selection#selection_on) to bind the necessary event listeners for dragging. The listeners use the name `.drag`, so you can subsequently unbind the drag behavior as follows:
+
+```js
+selection.on(".drag", null);
+```
+
+Applying the drag behavior also sets the [-webkit-tap-highlight-color](https://developer.apple.com/library/mac/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW5) style to transparent, disabling the tap highlight on iOS. If you want a different tap highlight color, remove or re-apply this style after applying the drag behavior.
+
+<a href="#drag_container" name="drag_container">#</a> <i>drag</i>.<b>container</b>([<i>container</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/collection/@d3/d3-drag)
+
+If *container* is specified, sets the container accessor to the specified object or function and returns the drag behavior. If *container* is not specified, returns the current container accessor, which defaults to:
+
+```js
+function container() {
+  return this.parentNode;
+}
+```
+
+The *container* of a drag gesture determines the coordinate system of subsequent [drag events](#drag-events), affecting *event*.x and *event*.y. The element returned by the container accessor is subsequently passed to [d3.pointer](https://github.com/d3/d3-selection#pointer) to determine the local coordinates of the pointer.
+
+The default container accessor returns the parent node of the element in the originating selection (see [*drag*](#_drag)) that received the initiating input event. This is often appropriate when dragging SVG or HTML elements, since those elements are typically positioned relative to a parent. For dragging graphical elements with a Canvas, however, you may want to redefine the container as the initiating element itself:
+
+```js
+function container() {
+  return this;
+}
+```
+
+Alternatively, the container may be specified as the element directly, such as `drag.container(canvas)`.
+
+
+<a href="#drag_filter" name="drag_filter">#</a> <i>drag</i>.<b>filter</b>([<i>filter</i>])  · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/d/c55a5839a5bb7c73)
+
+If *filter* is specified, sets the event filter to the specified function and returns the drag behavior. If *filter* is not specified, returns the current filter, which defaults to:
+
+```js
+function filter(event) {
+  return !event.ctrlKey && !event.button;
+}
+```
+
+If the filter returns falsey, the initiating event is ignored and no drag gestures are started. Thus, the filter determines which input events are ignored; the default filter ignores mousedown events on secondary buttons, since those buttons are typically intended for other purposes, such as the context menu.
+
+<a href="#drag_touchable" name="drag_touchable">#</a> <i>drag</i>.<b>touchable</b>([<i>touchable</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/d/c55a5839a5bb7c73)
+
+If *touchable* is specified, sets the touch support detector to the specified function and returns the drag behavior. If *touchable* is not specified, returns the current touch support detector, which defaults to:
+
+```js
+function touchable() {
+  return navigator.maxTouchPoints || ("ontouchstart" in this);
+}
+```
+
+Touch event listeners are only registered if the detector returns truthy for the corresponding element when the drag behavior is [applied](#_drag). The default detector works well for most browsers that are capable of touch input, but not all; Chrome’s mobile device emulator, for example, fails detection.
+
+<a href="#drag_subject" name="drag_subject">#</a> <i>drag</i>.<b>subject</b>([<i>subject</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js), [Examples](https://observablehq.com/collection/@d3/d3-drag)
+
+If *subject* is specified, sets the subject accessor to the specified object or function and returns the drag behavior. If *subject* is not specified, returns the current subject accessor, which defaults to:
+
+```js
+function subject(event, d) {
+  return d == null ? {x: event.x, y: event.y} : d;
+}
+```
+
+The *subject* of a drag gesture represents *the thing being dragged*. It is computed when an initiating input event is received, such as a mousedown or touchstart, immediately before the drag gesture starts. The subject is then exposed as *event*.subject on subsequent [drag events](#drag-events) for this gesture.
+
+The default subject is the [datum](https://github.com/d3/d3-selection#selection_datum) of the element in the originating selection (see [*drag*](#_drag)) that received the initiating input event; if this datum is undefined, an object representing the coordinates of the pointer is created. When dragging circle elements in SVG, the default subject is thus the datum of the circle being dragged. With [Canvas](https://html.spec.whatwg.org/multipage/scripting.html#the-canvas-element), the default subject is the canvas element’s datum (regardless of where on the canvas you click). In this case, a custom subject accessor would be more appropriate, such as one that picks the closest circle to the mouse within a given search *radius*:
+
+```js
+function subject(event) {
+  var n = circles.length,
+      i,
+      dx,
+      dy,
+      d2,
+      s2 = radius * radius,
+      circle,
+      subject;
+
+  for (i = 0; i < n; ++i) {
+    circle = circles[i];
+    dx = event.x - circle.x;
+    dy = event.y - circle.y;
+    d2 = dx * dx + dy * dy;
+    if (d2 < s2) subject = circle, s2 = d2;
+  }
+
+  return subject;
+}
+```
+
+(If necessary, the above can be accelerated using [*quadtree*.find](https://github.com/d3/d3-quadtree/blob/master/README.md#quadtree_find),  [*simulation*.find](https://github.com/d3/d3-force/blob/master/README.md#simulation_find) or [*delaunay*.find](https://github.com/d3/d3-delaunay/blob/master/README.md#delaunay_find).)
+
+The returned subject should be an object that exposes `x` and `y` properties, so that the relative position of the subject and the pointer can be preserved during the drag gesture. If the subject is null or undefined, no drag gesture is started for this pointer; however, other starting touches may yet start drag gestures. See also [*drag*.filter](#drag_filter).
+
+The subject of a drag gesture may not be changed after the gesture starts. The subject accessor is invoked with the same context and arguments as [*selection*.on](https://github.com/d3/d3-selection#selection_on) listeners: the current event (`event`) and datum `d`, with the `this` context as the current DOM element. During the evaluation of the subject accessor, `event` is a beforestart [drag event](#drag-events). Use *event*.sourceEvent to access the initiating input event and *event*.identifier to access the touch identifier. The *event*.x and *event*.y are relative to the [container](#drag_container), and are computed using [d3.pointer](https://github.com/d3/d3-selection#pointer).
+
+<a href="#drag_clickDistance" name="drag_clickDistance">#</a> <i>drag</i>.<b>clickDistance</b>([<i>distance</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js)
+
+If *distance* is specified, sets the maximum distance that the mouse can move between mousedown and mouseup that will trigger a subsequent click event. If at any point between mousedown and mouseup the mouse is greater than or equal to *distance* from its position on mousedown, the click event following mouseup will be suppressed. If *distance* is not specified, returns the current distance threshold, which defaults to zero. The distance threshold is measured in client coordinates ([*event*.clientX](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX) and [*event*.clientY](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientY)).
+
+<a href="#drag_on" name="drag_on">#</a> <i>drag</i>.<b>on</b>(<i>typenames</i>, [<i>listener</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/drag.js)
+
+If *listener* is specified, sets the event *listener* for the specified *typenames* and returns the drag behavior. If an event listener was already registered for the same type and name, the existing listener is removed before the new listener is added. If *listener* is null, removes the current event listeners for the specified *typenames*, if any. If *listener* is not specified, returns the first currently-assigned listener matching the specified *typenames*, if any. When a specified event is dispatched, each *listener* will be invoked with the same context and arguments as [*selection*.on](https://github.com/d3/d3-selection#selection_on) listeners: the current event (`event`) and datum `d`, with the `this` context as the current DOM element.
+
+The *typenames* is a string containing one or more *typename* separated by whitespace. Each *typename* is a *type*, optionally followed by a period (`.`) and a *name*, such as `drag.foo` and `drag.bar`; the name allows multiple listeners to be registered for the same *type*. The *type* must be one of the following:
+
+* `start` - after a new pointer becomes active (on mousedown or touchstart).
+* `drag` - after an active pointer moves (on mousemove or touchmove).
+* `end` - after an active pointer becomes inactive (on mouseup, touchend or touchcancel).
+
+See [*dispatch*.on](https://github.com/d3/d3-dispatch#dispatch_on) for more.
+
+Changes to registered listeners via *drag*.on during a drag gesture *do not affect* the current drag gesture. Instead, you must use [*event*.on](#event_on), which also allows you to register temporary event listeners for the current drag gesture. **Separate events are dispatched for each active pointer** during a drag gesture. For example, if simultaneously dragging multiple subjects with multiple fingers, a start event is dispatched for each finger, even if both fingers start touching simultaneously. See [Drag Events](#drag-events) for more.
+
+<a href="#dragDisable" name="dragDisable">#</a> d3.<b>dragDisable</b>(<i>window</i>) · [Source](https://github.com/d3/d3-drag/blob/master/src/nodrag.js)
+
+Prevents native drag-and-drop and text selection on the specified *window*. As an alternative to preventing the default action of mousedown events (see [#9](https://github.com/d3/d3-drag/issues/9)), this method prevents undesirable default actions following mousedown. In supported browsers, this means capturing dragstart and selectstart events, preventing the associated default actions, and immediately stopping their propagation. In browsers that do not support selection events, the user-select CSS property is set to none on the document element. This method is intended to be called on mousedown, followed by [d3.dragEnable](#dragEnable) on mouseup.
+
+<a href="#dragEnable" name="dragEnable">#</a> d3.<b>dragEnable</b>(<i>window</i>[, <i>noclick</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/nodrag.js)
+
+Allows native drag-and-drop and text selection on the specified *window*; undoes the effect of [d3.dragDisable](#dragDisable). This method is intended to be called on mouseup, preceded by [d3.dragDisable](#dragDisable) on mousedown. If *noclick* is true, this method also temporarily suppresses click events. The suppression of click events expires after a zero-millisecond timeout, such that it only suppress the click event that would immediately follow the current mouseup event, if any.
+
+### Drag Events
+
+When a [drag event listener](#drag_on) is invoked, it receives the current drag event as its first argument. The *event* object exposes several fields:
+
+* `target` - the associated [drag behavior](#drag).
+* `type` - the string “start”, “drag” or “end”; see [*drag*.on](#drag_on).
+* `subject` - the drag subject, defined by [*drag*.subject](#drag_subject).
+* `x` - the new *x*-coordinate of the subject; see [*drag*.container](#drag_container).
+* `y` - the new *y*-coordinate of the subject; see [*drag*.container](#drag_container).
+* `dx` - the change in *x*-coordinate since the previous drag event.
+* `dy` - the change in *y*-coordinate since the previous drag event.
+* `identifier` - the string “mouse”, or a numeric [touch identifier](https://www.w3.org/TR/touch-events/#widl-Touch-identifier).
+* `active` - the number of currently active drag gestures (on start and end, not including this one).
+* `sourceEvent` - the underlying input event, such as mousemove or touchmove.
+
+The *event*.active field is useful for detecting the first start event and the last end event in a sequence of concurrent drag gestures: it is zero when the first drag gesture starts, and zero when the last drag gesture ends.
+
+The *event* object also exposes the [*event*.on](#event_on) method.
+
+<a href="#event_on" name="event_on">#</a> <i>event</i>.<b>on</b>(<i>typenames</i>, [<i>listener</i>]) · [Source](https://github.com/d3/d3-drag/blob/master/src/event.js)
+
+Equivalent to [*drag*.on](#drag_on), but only applies to the current drag gesture. Before the drag gesture starts, a [copy](https://github.com/d3/d3-dispatch#dispatch_copy) of the current drag [event listeners](#drag_on) is made. This copy is bound to the current drag gesture and modified by *event*.on. This is useful for temporary listeners that only receive events for the current drag gesture. For example, this start event listener registers temporary drag and end event listeners as closures:
+
+```js
+function started(event) {
+  var circle = d3.select(this).classed("dragging", true);
+
+  event.on("drag", dragged).on("end", ended);
+
+  function dragged(event, d) {
+    circle.raise().attr("cx", d.x = event.x).attr("cy", d.y = event.y);
+  }
+
+  function ended() {
+    circle.classed("dragging", false);
+  }
+}
+```

--- a/node_modules/d3-drag/package.json
+++ b/node_modules/d3-drag/package.json
@@ -1,0 +1,76 @@
+{
+  "_from": "d3-drag",
+  "_id": "d3-drag@2.0.0",
+  "_inBundle": false,
+  "_integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+  "_location": "/d3-drag",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "d3-drag",
+    "name": "d3-drag",
+    "escapedName": "d3-drag",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+  "_shasum": "9eaf046ce9ed1c25c88661911c1d5a4d8eb7ea6d",
+  "_spec": "d3-drag",
+  "_where": "/Users/Kelly/Downloads/edamontology/edam-browser",
+  "author": {
+    "name": "Mike Bostock",
+    "url": "http://bost.ocks.org/mike"
+  },
+  "bugs": {
+    "url": "https://github.com/d3/d3-drag/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "d3-dispatch": "1 - 2",
+    "d3-selection": "2"
+  },
+  "deprecated": false,
+  "description": "Drag and drop SVG, HTML or Canvas using mouse or touch input.",
+  "devDependencies": {
+    "eslint": "6",
+    "rollup": "1",
+    "rollup-plugin-terser": "5",
+    "tape": "4"
+  },
+  "files": [
+    "dist/**/*.js",
+    "src/**/*.js"
+  ],
+  "homepage": "https://d3js.org/d3-drag/",
+  "jsdelivr": "dist/d3-drag.min.js",
+  "keywords": [
+    "d3",
+    "d3-module",
+    "drag",
+    "behavior",
+    "interaction"
+  ],
+  "license": "BSD-3-Clause",
+  "main": "dist/d3-drag.js",
+  "module": "src/index.js",
+  "name": "d3-drag",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/d3/d3-drag.git"
+  },
+  "scripts": {
+    "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../${npm_package_name}/dist/${npm_package_name}.js ${npm_package_name}.v${npm_package_version%%.*}.js && cp ../${npm_package_name}/dist/${npm_package_name}.min.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git add ${npm_package_name}.v${npm_package_version%%.*}.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git commit -m \"${npm_package_name} ${npm_package_version}\" && git push && cd - && zip -j dist/${npm_package_name}.zip -- LICENSE README.md dist/${npm_package_name}.js dist/${npm_package_name}.min.js",
+    "prepublishOnly": "rm -rf dist && yarn test",
+    "pretest": "rollup -c",
+    "test": "tape 'test/**/*-test.js' && eslint src"
+  },
+  "sideEffects": false,
+  "unpkg": "dist/d3-drag.min.js",
+  "version": "2.0.0"
+}

--- a/node_modules/d3-drag/src/constant.js
+++ b/node_modules/d3-drag/src/constant.js
@@ -1,0 +1,1 @@
+export default x => () => x;

--- a/node_modules/d3-drag/src/drag.js
+++ b/node_modules/d3-drag/src/drag.js
@@ -1,0 +1,192 @@
+import {dispatch} from "d3-dispatch";
+import {select, pointer} from "d3-selection";
+import nodrag, {yesdrag} from "./nodrag.js";
+import noevent, {nopropagation} from "./noevent.js";
+import constant from "./constant.js";
+import DragEvent from "./event.js";
+
+// Ignore right-click, since that should open the context menu.
+function defaultFilter(event) {
+  return !event.ctrlKey && !event.button;
+}
+
+function defaultContainer() {
+  return this.parentNode;
+}
+
+function defaultSubject(event, d) {
+  return d == null ? {x: event.x, y: event.y} : d;
+}
+
+function defaultTouchable() {
+  return navigator.maxTouchPoints || ("ontouchstart" in this);
+}
+
+export default function() {
+  var filter = defaultFilter,
+      container = defaultContainer,
+      subject = defaultSubject,
+      touchable = defaultTouchable,
+      gestures = {},
+      listeners = dispatch("start", "drag", "end"),
+      active = 0,
+      mousedownx,
+      mousedowny,
+      mousemoving,
+      touchending,
+      clickDistance2 = 0;
+
+  function drag(selection) {
+    selection
+        .on("mousedown.drag", mousedowned)
+      .filter(touchable)
+        .on("touchstart.drag", touchstarted)
+        .on("touchmove.drag", touchmoved)
+        .on("touchend.drag touchcancel.drag", touchended)
+        .style("touch-action", "none")
+        .style("-webkit-tap-highlight-color", "rgba(0,0,0,0)");
+  }
+
+  function mousedowned(event, d) {
+    if (touchending || !filter.call(this, event, d)) return;
+    var gesture = beforestart(this, container.call(this, event, d), event, d, "mouse");
+    if (!gesture) return;
+    select(event.view).on("mousemove.drag", mousemoved, true).on("mouseup.drag", mouseupped, true);
+    nodrag(event.view);
+    nopropagation(event);
+    mousemoving = false;
+    mousedownx = event.clientX;
+    mousedowny = event.clientY;
+    gesture("start", event);
+  }
+
+  function mousemoved(event) {
+    noevent(event);
+    if (!mousemoving) {
+      var dx = event.clientX - mousedownx, dy = event.clientY - mousedowny;
+      mousemoving = dx * dx + dy * dy > clickDistance2;
+    }
+    gestures.mouse("drag", event);
+  }
+
+  function mouseupped(event) {
+    select(event.view).on("mousemove.drag mouseup.drag", null);
+    yesdrag(event.view, mousemoving);
+    noevent(event);
+    gestures.mouse("end", event);
+  }
+
+  function touchstarted(event, d) {
+    if (!filter.call(this, event, d)) return;
+    var touches = event.changedTouches,
+        c = container.call(this, event, d),
+        n = touches.length, i, gesture;
+
+    for (i = 0; i < n; ++i) {
+      if (gesture = beforestart(this, c, event, d, touches[i].identifier, touches[i])) {
+        nopropagation(event);
+        gesture("start", event, touches[i]);
+      }
+    }
+  }
+
+  function touchmoved(event) {
+    var touches = event.changedTouches,
+        n = touches.length, i, gesture;
+
+    for (i = 0; i < n; ++i) {
+      if (gesture = gestures[touches[i].identifier]) {
+        noevent(event);
+        gesture("drag", event, touches[i]);
+      }
+    }
+  }
+
+  function touchended(event) {
+    var touches = event.changedTouches,
+        n = touches.length, i, gesture;
+
+    if (touchending) clearTimeout(touchending);
+    touchending = setTimeout(function() { touchending = null; }, 500); // Ghost clicks are delayed!
+    for (i = 0; i < n; ++i) {
+      if (gesture = gestures[touches[i].identifier]) {
+        nopropagation(event);
+        gesture("end", event, touches[i]);
+      }
+    }
+  }
+
+  function beforestart(that, container, event, d, identifier, touch) {
+    var dispatch = listeners.copy(),
+        p = pointer(touch || event, container), dx, dy,
+        s;
+
+    if ((s = subject.call(that, new DragEvent("beforestart", {
+        sourceEvent: event,
+        target: drag,
+        identifier,
+        active,
+        x: p[0],
+        y: p[1],
+        dx: 0,
+        dy: 0,
+        dispatch
+      }), d)) == null) return;
+
+    dx = s.x - p[0] || 0;
+    dy = s.y - p[1] || 0;
+
+    return function gesture(type, event, touch) {
+      var p0 = p, n;
+      switch (type) {
+        case "start": gestures[identifier] = gesture, n = active++; break;
+        case "end": delete gestures[identifier], --active; // nobreak
+        case "drag": p = pointer(touch || event, container), n = active; break;
+      }
+      dispatch.call(
+        type,
+        that,
+        new DragEvent(type, {
+          sourceEvent: event,
+          subject: s,
+          target: drag,
+          identifier,
+          active: n,
+          x: p[0] + dx,
+          y: p[1] + dy,
+          dx: p[0] - p0[0],
+          dy: p[1] - p0[1],
+          dispatch
+        }),
+        d
+      );
+    };
+  }
+
+  drag.filter = function(_) {
+    return arguments.length ? (filter = typeof _ === "function" ? _ : constant(!!_), drag) : filter;
+  };
+
+  drag.container = function(_) {
+    return arguments.length ? (container = typeof _ === "function" ? _ : constant(_), drag) : container;
+  };
+
+  drag.subject = function(_) {
+    return arguments.length ? (subject = typeof _ === "function" ? _ : constant(_), drag) : subject;
+  };
+
+  drag.touchable = function(_) {
+    return arguments.length ? (touchable = typeof _ === "function" ? _ : constant(!!_), drag) : touchable;
+  };
+
+  drag.on = function() {
+    var value = listeners.on.apply(listeners, arguments);
+    return value === listeners ? drag : value;
+  };
+
+  drag.clickDistance = function(_) {
+    return arguments.length ? (clickDistance2 = (_ = +_) * _, drag) : Math.sqrt(clickDistance2);
+  };
+
+  return drag;
+}

--- a/node_modules/d3-drag/src/event.js
+++ b/node_modules/d3-drag/src/event.js
@@ -1,0 +1,28 @@
+export default function DragEvent(type, {
+  sourceEvent,
+  subject,
+  target,
+  identifier,
+  active,
+  x, y, dx, dy,
+  dispatch
+}) {
+  Object.defineProperties(this, {
+    type: {value: type, enumerable: true, configurable: true},
+    sourceEvent: {value: sourceEvent, enumerable: true, configurable: true},
+    subject: {value: subject, enumerable: true, configurable: true},
+    target: {value: target, enumerable: true, configurable: true},
+    identifier: {value: identifier, enumerable: true, configurable: true},
+    active: {value: active, enumerable: true, configurable: true},
+    x: {value: x, enumerable: true, configurable: true},
+    y: {value: y, enumerable: true, configurable: true},
+    dx: {value: dx, enumerable: true, configurable: true},
+    dy: {value: dy, enumerable: true, configurable: true},
+    _: {value: dispatch}
+  });
+}
+
+DragEvent.prototype.on = function() {
+  var value = this._.on.apply(this._, arguments);
+  return value === this._ ? this : value;
+};

--- a/node_modules/d3-drag/src/index.js
+++ b/node_modules/d3-drag/src/index.js
@@ -1,0 +1,2 @@
+export {default as drag} from "./drag.js";
+export {default as dragDisable, yesdrag as dragEnable} from "./nodrag.js";

--- a/node_modules/d3-drag/src/nodrag.js
+++ b/node_modules/d3-drag/src/nodrag.js
@@ -1,0 +1,28 @@
+import {select} from "d3-selection";
+import noevent from "./noevent.js";
+
+export default function(view) {
+  var root = view.document.documentElement,
+      selection = select(view).on("dragstart.drag", noevent, true);
+  if ("onselectstart" in root) {
+    selection.on("selectstart.drag", noevent, true);
+  } else {
+    root.__noselect = root.style.MozUserSelect;
+    root.style.MozUserSelect = "none";
+  }
+}
+
+export function yesdrag(view, noclick) {
+  var root = view.document.documentElement,
+      selection = select(view).on("dragstart.drag", null);
+  if (noclick) {
+    selection.on("click.drag", noevent, true);
+    setTimeout(function() { selection.on("click.drag", null); }, 0);
+  }
+  if ("onselectstart" in root) {
+    selection.on("selectstart.drag", null);
+  } else {
+    root.style.MozUserSelect = root.__noselect;
+    delete root.__noselect;
+  }
+}

--- a/node_modules/d3-drag/src/noevent.js
+++ b/node_modules/d3-drag/src/noevent.js
@@ -1,0 +1,8 @@
+export function nopropagation(event) {
+  event.stopImmediatePropagation();
+}
+
+export default function(event) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}

--- a/node_modules/d3-selection/LICENSE
+++ b/node_modules/d3-selection/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2010-2018, Michael Bostock
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* The name Michael Bostock may not be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/node_modules/d3-selection/README.md
+++ b/node_modules/d3-selection/README.md
@@ -1,0 +1,859 @@
+# d3-selection
+
+Selections allow powerful data-driven transformation of the document object model (DOM): set [attributes](#selection_attr), [styles](#selection_style), [properties](#selection_property), [HTML](#selection_html) or [text](#selection_text) content, and more. Using the [data join](#joining-data)’s [enter](#selection_enter) and [exit](#selection_enter) selections, you can also [add](#selection_append) or [remove](#selection_remove) elements to correspond to data.
+
+Selection methods typically return the current selection, or a new selection, allowing the concise application of multiple operations on a given selection via method chaining. For example, to set the class and color style of all paragraph elements in the current document:
+
+```js
+d3.selectAll("p")
+    .attr("class", "graf")
+    .style("color", "red");
+```
+
+This is equivalent to:
+
+```js
+const p = d3.selectAll("p");
+p.attr("class", "graf");
+p.style("color", "red");
+```
+
+By convention, selection methods that return the current selection use *four* spaces of indent, while methods that return a new selection use only *two*. This helps reveal changes of context by making them stick out of the chain:
+
+```js
+d3.select("body")
+  .append("svg")
+    .attr("width", 960)
+    .attr("height", 500)
+  .append("g")
+    .attr("transform", "translate(20,20)")
+  .append("rect")
+    .attr("width", 920)
+    .attr("height", 460);
+```
+
+Selections are immutable. All selection methods that affect which elements are selected (or their order) return a new selection rather than modifying the current selection. However, note that elements are necessarily mutable, as selections drive transformations of the document!
+
+For more, see [the d3-selection collection on Observable](https://observablehq.com/collection/@d3/d3-selection).
+
+## Installing
+
+If you use NPM, `npm install d3-selection`. Otherwise, download the [latest release](https://github.com/d3/d3-selection/releases/latest). You can also load d3-selection as a standalone library or as part of [D3](https://github.com/d3/d3). ES modules, AMD, CommonJS, and vanilla environments are supported. In vanilla, a `d3` global is exported:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/d3-selection@2"></script>
+<script>
+
+const div = d3.selectAll("div");
+
+</script>
+```
+
+[Try d3-selection in your browser.](https://observablehq.com/collection/@d3/d3-selection)
+
+## API Reference
+
+* [Selecting Elements](#selecting-elements)
+* [Modifying Elements](#modifying-elements)
+* [Joining Data](#joining-data)
+* [Handling Events](#handling-events)
+* [Control Flow](#control-flow)
+* [Local Variables](#local-variables)
+* [Namespaces](#namespaces)
+
+### Selecting Elements
+
+Selection methods accept [W3C selector strings](http://www.w3.org/TR/selectors-api/) such as `.fancy` to select elements with the class *fancy*, or `div` to select DIV elements. Selection methods come in two forms: select and selectAll: the former selects only the first matching element, while the latter selects all matching elements in document order. The top-level selection methods, [d3.select](#select) and [d3.selectAll](#selectAll), query the entire document; the subselection methods, [*selection*.select](#selection_select) and [*selection*.selectAll](#selection_selectAll), restrict selection to descendants of the selected elements.
+
+<a name="selection" href="#selection">#</a> d3.<b>selection</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/index.js)
+
+[Selects](#select) the root element, `document.documentElement`. This function can also be used to test for selections (`instanceof d3.selection`) or to extend the selection prototype. For example, to add a method to check checkboxes:
+
+```js
+d3.selection.prototype.checked = function(value) {
+  return arguments.length < 1
+      ? this.property("checked")
+      : this.property("checked", !!value);
+};
+```
+
+And then to use:
+
+```js
+d3.selectAll("input[type=checkbox]").checked(true);
+```
+
+<a name="select" href="#select">#</a> d3.<b>select</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/select.js)
+
+Selects the first element that matches the specified *selector* string. If no elements match the *selector*, returns an empty selection. If multiple elements match the *selector*, only the first matching element (in document order) will be selected. For example, to select the first anchor element:
+
+```js
+const anchor = d3.select("a");
+```
+
+If the *selector* is not a string, instead selects the specified node; this is useful if you already have a reference to a node, such as `this` within an event listener or a global such as `document.body`. For example, to make a clicked paragraph red:
+
+```js
+d3.selectAll("p").on("click", function(event) {
+  d3.select(this).style("color", "red");
+});
+```
+
+<a name="selectAll" href="#selectAll">#</a> d3.<b>selectAll</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selectAll.js)
+
+Selects all elements that match the specified *selector* string. The elements will be selected in document order (top-to-bottom). If no elements in the document match the *selector*, or if the *selector* is null or undefined, returns an empty selection. For example, to select all paragraphs:
+
+```js
+const paragraph = d3.selectAll("p");
+```
+
+If the *selector* is not a string, instead selects the specified array of nodes; this is useful if you already have a reference to nodes, such as `this.childNodes` within an event listener or a global such as `document.links`. The nodes may instead be an iterable, or a pseudo-array such as a NodeList. For example, to color all links red:
+
+```js
+d3.selectAll(document.links).style("color", "red");
+```
+
+<a name="selection_select" href="#selection_select">#</a> <i>selection</i>.<b>select</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/select.js)
+
+For each selected element, selects the first descendant element that matches the specified *selector* string. If no element matches the specified selector for the current element, the element at the current index will be null in the returned selection. (If the *selector* is null, every element in the returned selection will be null, resulting in an empty selection.) If the current element has associated data, this data is propagated to the corresponding selected element. If multiple elements match the selector, only the first matching element in document order is selected. For example, to select the first bold element in every paragraph:
+
+```js
+const b = d3.selectAll("p").select("b");
+```
+
+If the *selector* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). It must return an element, or null if there is no matching element. For example, to select the previous sibling of each paragraph:
+
+```js
+const previous = d3.selectAll("p").select(function() {
+  return this.previousElementSibling;
+});
+```
+
+Unlike [*selection*.selectAll](#selection_selectAll), *selection*.select does not affect grouping: it preserves the existing group structure and indexes, and propagates data (if any) to selected children. Grouping plays an important role in the [data join](#joining-data). See [Nested Selections](http://bost.ocks.org/mike/nest/) and [How Selections Work](http://bost.ocks.org/mike/selection/) for more on this topic.
+
+<a name="selection_selectAll" href="#selection_selectAll">#</a> <i>selection</i>.<b>selectAll</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/selectAll.js)
+
+For each selected element, selects the descendant elements that match the specified *selector* string. The elements in the returned selection are grouped by their corresponding parent node in this selection. If no element matches the specified selector for the current element, or if the *selector* is null, the group at the current index will be empty. The selected elements do not inherit data from this selection; use [*selection*.data](#selection_data) to propagate data to children. For example, to select the bold elements in every paragraph:
+
+```js
+const b = d3.selectAll("p").selectAll("b");
+```
+
+If the *selector* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). It must return an array of elements (or an iterable, or a pseudo-array such as a NodeList), or the empty array if there are no matching elements. For example, to select the previous and next siblings of each paragraph:
+
+```js
+const sibling = d3.selectAll("p").selectAll(function() {
+  return [
+    this.previousElementSibling,
+    this.nextElementSibling
+  ];
+});
+```
+
+Unlike [*selection*.select](#selection_select), *selection*.selectAll does affect grouping: each selected descendant is grouped by the parent element in the originating selection. Grouping plays an important role in the [data join](#joining-data). See [Nested Selections](http://bost.ocks.org/mike/nest/) and [How Selections Work](http://bost.ocks.org/mike/selection/) for more on this topic.
+
+<a name="selection_filter" href="#selection_filter">#</a> <i>selection</i>.<b>filter</b>(<i>filter</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/filter.js)
+
+Filters the selection, returning a new selection that contains only the elements for which the specified *filter* is true. The *filter* may be specified either as a selector string or a function. If the *filter* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]).
+
+For example, to filter a selection of table rows to contain only even rows:
+
+```js
+const even = d3.selectAll("tr").filter(":nth-child(even)");
+```
+
+This is approximately equivalent to using [d3.selectAll](#selectAll) directly, although the indexes may be different:
+
+```js
+const even = d3.selectAll("tr:nth-child(even)");
+```
+
+Similarly, using a function:
+
+```js
+const even = d3.selectAll("tr").filter((d, i) => i & 1);
+```
+
+Or using [*selection*.select](#selection_select) (and avoiding an arrow function, since *this* is needed to refer to the current element):
+
+```js
+const even = d3.selectAll("tr").select(function(d, i) { return i & 1 ? this : null; });
+```
+
+Note that the `:nth-child` pseudo-class is a one-based index rather than a zero-based index. Also, the above filter functions do not have precisely the same meaning as `:nth-child`; they rely on the selection index rather than the number of preceding sibling elements in the DOM.
+
+The returned filtered selection preserves the parents of this selection, but like [*array*.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter), it does not preserve indexes as some elements may be removed; use [*selection*.select](#selection_select) to preserve the index, if needed.
+
+<a name="selection_merge" href="#selection_merge">#</a> <i>selection</i>.<b>merge</b>(<i>other</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/merge.js)
+
+Returns a new selection merging this selection with the specified *other* selection. The returned selection has the same number of groups and the same parents as this selection. Any missing (null) elements in this selection are filled with the corresponding element, if present (not null), from the specified *selection*. (If the *other* selection has additional groups or parents, they are ignored.)
+
+This method is used internally by [*selection*.join](#selection_join) to merge the [enter](#selection_enter) and [update](#selection_data) selections after [binding data](#joining-data). You can also merge explicitly, although note that since merging is based on element index, you should use operations that preserve index, such as [*selection*.select](#selection_select) instead of [*selection*.filter](#selection_filter). For example:
+
+```js
+const odd = selection.select(function(d, i) { return i & 1 ? this : null; ));
+const even = selection.select(function(d, i) { return i & 1 ? null : this; ));
+const merged = odd.merge(even);
+```
+
+See [*selection*.data](#selection_data) for more.
+
+This method is not intended for concatenating arbitrary selections, however: if both this selection and the specified *other* selection have (non-null) elements at the same index, this selection’s element is returned in the merge and the *other* selection’s element is ignored.
+
+<a name="selection_selectChild" href="#selection_selectChild">#</a> <i>selection</i>.<b>selectChild</b>([<i>selector</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/selectChild.js)
+
+Returns a new selection with the (first) child of each element of the current selection matching the *selector*. If no *selector* is specified, selects the first child (if any). If the *selector* is specified as a string, selects the first child that matches (if any). If the *selector* is a function, it is evaluated for each of the children nodes, in order, being passed the child (*child*), the child’s index (*i*), and the list of children (*children*); the method selects the first child for which the selector return truthy, if any.
+
+<a name="selection_selectChildren" href="#selection_selectChildren">#</a> <i>selection</i>.<b>selectChildren</b>([<i>selector</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/selectChildren.js)
+
+Returns a new selection with the children of each element of the current selection matching the *selector*. If no *selector* is specified, selects all the children. If the *selector* is specified as a string, selects the children that match (if any). If the *selector* is a function, it is evaluated for each of the children nodes, in order, being passed the child (*child*), the child’s index (*i*), and the list of children (*children*); the method selects all children for which the selector return truthy.
+
+<a name="selection_selection" href="#selection_selection">#</a> <i>selection</i>.<b>selection</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/index.js)
+
+Returns the selection (for symmetry with [<i>transition</i>.selection](https://github.com/d3/d3-transition/blob/master/README.md#transition_selection)).
+
+<a name="matcher" href="#matcher">#</a> d3.<b>matcher</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/matcher.js)
+
+Given the specified *selector*, returns a function which returns true if `this` element [matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) the specified selector. This method is used internally by [*selection*.filter](#selection_filter). For example, this:
+
+```js
+const div = selection.filter("div");
+```
+
+Is equivalent to:
+
+```js
+const div = selection.filter(d3.matcher("div"));
+```
+
+(Although D3 is not a compatibility layer, this implementation does support vendor-prefixed implementations due to the recent standardization of *element*.matches.)
+
+<a name="selector" href="#selector">#</a> d3.<b>selector</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selector.js)
+
+Given the specified *selector*, returns a function which returns the first descendant of `this` element that matches the specified selector. This method is used internally by [*selection*.select](#selection_select). For example, this:
+
+```js
+const div = selection.select("div");
+```
+
+Is equivalent to:
+
+```js
+const div = selection.select(d3.selector("div"));
+```
+
+<a name="selectorAll" href="#selectorAll">#</a> d3.<b>selectorAll</b>(<i>selector</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selectAll.js)
+
+Given the specified *selector*, returns a function which returns all descendants of `this` element that match the specified selector. This method is used internally by [*selection*.selectAll](#selection_selectAll). For example, this:
+
+```js
+const div = selection.selectAll("div");
+```
+
+Is equivalent to:
+
+```js
+const div = selection.selectAll(d3.selectorAll("div"));
+```
+
+<a name="window" href="#window">#</a> d3.<b>window</b>(<i>node</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/window.js)
+
+Returns the owner window for the specified *node*. If *node* is a node, returns the owner document’s default view; if *node* is a document, returns its default view; otherwise returns the *node*.
+
+<a name="style" href="#style">#</a> d3.<b>style</b>(<i>node</i>, <i>name</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/style.js)
+
+Returns the value of the style property with the specified *name* for the specified *node*. If the *node* has an inline style with the specified *name*, its value is returned; otherwise, the [computed property value](https://developer.mozilla.org/en-US/docs/Web/CSS/computed_value) is returned. See also [*selection*.style](#selection_style).
+
+### Modifying Elements
+
+After selecting elements, use the selection’s transformation methods to affect document content. For example, to set the name attribute and color style of an anchor element:
+
+```js
+d3.select("a")
+    .attr("name", "fred")
+    .style("color", "red");
+```
+
+To experiment with selections, visit [d3js.org](https://d3js.org) and open your browser’s developer console! (In Chrome, open the console with ⌥⌘J.) Select elements and then inspect the returned selection to see which elements are selected and how they are grouped. Call selection methods and see how the page content changes.
+
+<a name="selection_attr" href="#selection_attr">#</a> <i>selection</i>.<b>attr</b>(<i>name</i>[, <i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/attr.js)
+
+If a *value* is specified, sets the attribute with the specified *name* to the specified value on the selected elements and returns this selection. If the *value* is a constant, all elements are given the same attribute value; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to set each element’s attribute. A null value will remove the specified attribute.
+
+If a *value* is not specified, returns the current value of the specified attribute for the first (non-null) element in the selection. This is generally useful only if you know that the selection contains exactly one element.
+
+The specified *name* may have a namespace prefix, such as `xlink:href` to specify the `href` attribute in the XLink namespace. See [namespaces](#namespaces) for the map of supported namespaces; additional namespaces can be registered by adding to the map.
+
+<a name="selection_classed" href="#selection_classed">#</a> <i>selection</i>.<b>classed</b>(<i>names</i>[, <i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/classed.js)
+
+If a *value* is specified, assigns or unassigns the specified CSS class *names* on the selected elements by setting the `class` attribute or modifying the `classList` property and returns this selection. The specified *names* is a string of space-separated class names. For example, to assign the classes `foo` and `bar` to the selected elements:
+
+```js
+selection.classed("foo bar", true);
+```
+
+If the *value* is truthy, then all elements are assigned the specified classes; otherwise, the classes are unassigned. If the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to assign or unassign classes on each element. For example, to randomly associate the class *foo* with on average half the selected elements:
+
+```js
+selection.classed("foo", () => Math.random() > 0.5);
+```
+
+If a *value* is not specified, returns true if and only if the first (non-null) selected element has the specified *classes*. This is generally useful only if you know the selection contains exactly one element.
+
+<a name="selection_style" href="#selection_style">#</a> <i>selection</i>.<b>style</b>(<i>name</i>[, <i>value</i>[, <i>priority</i>]]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/style.js)
+
+If a *value* is specified, sets the style property with the specified *name* to the specified value on the selected elements and returns this selection. If the *value* is a constant, then all elements are given the same style property value; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to set each element’s style property. A null value will remove the style property. An optional *priority* may also be specified, either as null or the string `important` (without the exclamation point).
+
+If a *value* is not specified, returns the current value of the specified style property for the first (non-null) element in the selection. The current value is defined as the element’s inline value, if present, and otherwise its [computed value](https://developer.mozilla.org/en-US/docs/Web/CSS/computed_value). Accessing the current style value is generally useful only if you know the selection contains exactly one element.
+
+Caution: unlike many SVG attributes, CSS styles typically have associated units. For example, `3px` is a valid stroke-width property value, while `3` is not. Some browsers implicitly assign the `px` (pixel) unit to numeric values, but not all browsers do: IE, for example, throws an “invalid arguments” error!
+
+<a name="selection_property" href="#selection_property">#</a> <i>selection</i>.<b>property</b>(<i>name</i>[, <i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/property.js)
+
+Some HTML elements have special properties that are not addressable using attributes or styles, such as a form field’s text `value` and a checkbox’s `checked` boolean. Use this method to get or set these properties.
+
+If a *value* is specified, sets the property with the specified *name* to the specified value on selected elements. If the *value* is a constant, then all elements are given the same property value; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to set each element’s property. A null value will delete the specified property.
+
+If a *value* is not specified, returns the value of the specified property for the first (non-null) element in the selection. This is generally useful only if you know the selection contains exactly one element.
+
+<a name="selection_text" href="#selection_text">#</a> <i>selection</i>.<b>text</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/text.js)
+
+If a *value* is specified, sets the [text content](http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent) to the specified value on all selected elements, replacing any existing child elements. If the *value* is a constant, then all elements are given the same text content; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to set each element’s text content. A null value will clear the content.
+
+If a *value* is not specified, returns the text content for the first (non-null) element in the selection. This is generally useful only if you know the selection contains exactly one element.
+
+<a name="selection_html" href="#selection_html">#</a> <i>selection</i>.<b>html</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/html.js)
+
+If a *value* is specified, sets the [inner HTML](http://dev.w3.org/html5/spec-LC/apis-in-html-documents.html#innerhtml) to the specified value on all selected elements, replacing any existing child elements. If the *value* is a constant, then all elements are given the same inner HTML; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function’s return value is then used to set each element’s inner HTML. A null value will clear the content.
+
+If a *value* is not specified, returns the inner HTML for the first (non-null) element in the selection. This is generally useful only if you know the selection contains exactly one element.
+
+Use [*selection*.append](#selection_append) or [*selection*.insert](#selection_insert) instead to create data-driven content; this method is intended for when you want a little bit of HTML, say for rich formatting. Also, *selection*.html is only supported on HTML elements. SVG elements and other non-HTML elements do not support the innerHTML property, and thus are incompatible with *selection*.html. Consider using [XMLSerializer](https://developer.mozilla.org/en-US/docs/XMLSerializer) to convert a DOM subtree to text. See also the [innersvg polyfill](https://code.google.com/p/innersvg/), which provides a shim to support the innerHTML property on SVG elements.
+
+<a name="selection_append" href="#selection_append">#</a> <i>selection</i>.<b>append</b>(<i>type</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/append.js)
+
+If the specified *type* is a string, appends a new element of this type (tag name) as the last child of each selected element, or before the next following sibling in the update selection if this is an [enter selection](#selection_enter). The latter behavior for enter selections allows you to insert elements into the DOM in an order consistent with the new bound data; however, note that [*selection*.order](#selection_order) may still be required if updating elements change order (*i.e.*, if the order of new data is inconsistent with old data).
+
+If the specified *type* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). This function should return an element to be appended. (The function typically creates a new element, but it may instead return an existing element.) For example, to append a paragraph to each DIV element:
+
+```js
+d3.selectAll("div").append("p");
+```
+
+This is equivalent to:
+
+```js
+d3.selectAll("div").append(() => document.createElement("p"));
+```
+
+Which is equivalent to:
+
+```js
+d3.selectAll("div").select(function() {
+  return this.appendChild(document.createElement("p"));
+});
+```
+
+In both cases, this method returns a new selection containing the appended elements. Each new element inherits the data of the current elements, if any, in the same manner as [*selection*.select](#selection_select).
+
+The specified *name* may have a namespace prefix, such as `svg:text` to specify a `text` attribute in the SVG namespace. See [namespaces](#namespaces) for the map of supported namespaces; additional namespaces can be registered by adding to the map. If no namespace is specified, the namespace will be inherited from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used (for example, `svg` implies `svg:svg`).
+
+<a name="selection_insert" href="#selection_insert">#</a> <i>selection</i>.<b>insert</b>(<i>type</i>[, <i>before</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/insert.js)
+
+If the specified *type* is a string, inserts a new element of this type (tag name) before the first element matching the specified *before* selector for each selected element. For example, a *before* selector `:first-child` will prepend nodes before the first child. If *before* is not specified, it defaults to null. (To append elements in an order consistent with [bound data](#joining-data), use [*selection*.append](#selection_append).)
+
+Both *type* and *before* may instead be specified as functions which are evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The *type* function should return an element to be inserted; the *before* function should return the child element before which the element should be inserted. For example, to append a paragraph to each DIV element:
+
+```js
+d3.selectAll("div").insert("p");
+```
+
+This is equivalent to:
+
+```js
+d3.selectAll("div").insert(() => document.createElement("p"));
+```
+
+Which is equivalent to:
+
+```js
+d3.selectAll("div").select(function() {
+  return this.insertBefore(document.createElement("p"), null);
+});
+```
+
+In both cases, this method returns a new selection containing the appended elements. Each new element inherits the data of the current elements, if any, in the same manner as [*selection*.select](#selection_select).
+
+The specified *name* may have a namespace prefix, such as `svg:text` to specify a `text` attribute in the SVG namespace. See [namespaces](#namespaces) for the map of supported namespaces; additional namespaces can be registered by adding to the map. If no namespace is specified, the namespace will be inherited from the parent element; or, if the name is one of the known prefixes, the corresponding namespace will be used (for example, `svg` implies `svg:svg`).
+
+<a name="selection_remove" href="#selection_remove">#</a> <i>selection</i>.<b>remove</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/remove.js)
+
+Removes the selected elements from the document. Returns this selection (the removed elements) which are now detached from the DOM. There is not currently a dedicated API to add removed elements back to the document; however, you can pass a function to [*selection*.append](#selection_append) or [*selection*.insert](#selection_insert) to re-add elements.
+
+<a name="selection_clone" href="#selection_clone">#</a> <i>selection</i>.<b>clone</b>([<i>deep</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/clone.js)
+
+Inserts clones of the selected elements immediately following the selected elements and returns a selection of the newly added clones. If *deep* is truthy, the descendant nodes of the selected elements will be cloned as well. Otherwise, only the elements themselves will be cloned. Equivalent to:
+
+```js
+selection.select(function() {
+  return this.parentNode.insertBefore(this.cloneNode(deep), this.nextSibling);
+});
+```
+
+<a name="selection_sort" href="#selection_sort">#</a> <i>selection</i>.<b>sort</b>(<i>compare</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/sort.js)
+
+Returns a new selection that contains a copy of each group in this selection sorted according to the *compare* function. After sorting, re-inserts elements to match the resulting order (per [*selection*.order](#selection_order)).
+
+The compare function, which defaults to [ascending](https://github.com/d3/d3-array#ascending), is passed two elements’ data *a* and *b* to compare. It should return either a negative, positive, or zero value. If negative, then *a* should be before *b*; if positive, then *a* should be after *b*; otherwise, *a* and *b* are considered equal and the order is arbitrary.
+
+Note that sorting is not guaranteed to be stable; however, it is guaranteed to have the same behavior as your browser’s built-in [sort](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort) method on arrays.
+
+<a name="selection_order" href="#selection_order">#</a> <i>selection</i>.<b>order</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/order.js)
+
+Re-inserts elements into the document such that the document order of each group matches the selection order. This is equivalent to calling [*selection*.sort](#selection_sort) if the data is already sorted, but much faster.
+
+<a name="selection_raise" href="#selection_raise">#</a> <i>selection</i>.<b>raise</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/raise.js)
+
+Re-inserts each selected element, in order, as the last child of its parent. Equivalent to:
+
+```js
+selection.each(function() {
+  this.parentNode.appendChild(this);
+});
+```
+
+<a name="selection_lower" href="#selection_lower">#</a> <i>selection</i>.<b>lower</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/lower.js)
+
+Re-inserts each selected element, in order, as the first child of its parent. Equivalent to:
+
+```js
+selection.each(function() {
+  this.parentNode.insertBefore(this, this.parentNode.firstChild);
+});
+```
+
+<a name="create" href="#create">#</a> d3.<b>create</b>(<i>name</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/create.js)
+
+Given the specified element *name*, returns a single-element selection containing a detached element of the given name in the current document. This method assumes the HTML namespace, so you must specify a namespace explicitly when creating SVG or other non-HTML elements; see [namespace](#namespace) for details on supported namespace prefixes.
+
+```js
+d3.create("svg") // equivalent to svg:svg
+d3.create("svg:svg") // more explicitly
+d3.create("svg:g") // an SVG G element
+d3.create("g") // an HTML G (unknown) element
+```
+
+<a name="creator" href="#creator">#</a> d3.<b>creator</b>(<i>name</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/creator.js)
+
+Given the specified element *name*, returns a function which creates an element of the given name, assuming that `this` is the parent element. This method is used internally by [*selection*.append](#selection_append) and [*selection*.insert](#selection_insert) to create new elements. For example, this:
+
+```js
+selection.append("div");
+```
+
+Is equivalent to:
+
+```js
+selection.append(d3.creator("div"));
+```
+
+See [namespace](#namespace) for details on supported namespace prefixes, such as for SVG elements.
+
+### Joining Data
+
+For an introduction to D3’s data joins, see the [*selection*.join notebook](https://observablehq.com/@d3/selection-join). Also see [Thinking With Joins](http://bost.ocks.org/mike/join/).
+
+<a name="selection_data" href="#selection_data">#</a> <i>selection</i>.<b>data</b>([<i>data</i>[, <i>key</i>]]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/data.js)
+
+Binds the specified array of *data* with the selected elements, returning a new selection that represents the *update* selection: the elements successfully bound to data. Also defines the [enter](#selection_enter) and [exit](#selection_exit) selections on the returned selection, which can be used to add or remove elements to correspond to the new data. The specified *data* is an array of arbitrary values (*e.g.*, numbers or objects), or a function that returns an array of values for each group. When data is assigned to an element, it is stored in the property `__data__`, thus making the data “sticky” and available on re-selection.
+
+The *data* is specified **for each group** in the selection. If the selection has multiple groups (such as [d3.selectAll](#selectAll) followed by [*selection*.selectAll](#selection_selectAll)), then *data* should typically be specified as a function. This function will be evaluated for each group in order, being passed the group’s parent datum (*d*, which may be undefined), the group index (*i*), and the selection’s parent nodes (*nodes*), with *this* as the group’s parent element.
+
+In conjunction with [*selection*.join](#selection_join) (or more explicitly with [*selection*.enter](#selection_enter), [*selection*.exit](#selection_exit), [*selection*.append](#selection_append) and [*selection*.remove](#selection_remove)), *selection*.data can be used to enter, update and exit elements to match data. For example, to create an HTML table from a matrix of numbers:
+
+```js
+const matrix = [
+  [11975,  5871, 8916, 2868],
+  [ 1951, 10048, 2060, 6171],
+  [ 8010, 16145, 8090, 8045],
+  [ 1013,   990,  940, 6907]
+];
+
+d3.select("body")
+  .append("table")
+  .selectAll("tr")
+  .data(matrix)
+  .join("tr")
+  .selectAll("td")
+  .data(d => d)
+  .join("td")
+    .text(d => d);
+```
+
+In this example the *data* function is the identity function: for each table row, it returns the corresponding row from the data matrix.
+
+If a *key* function is not specified, then the first datum in *data* is assigned to the first selected element, the second datum to the second selected element, and so on. A *key* function may be specified to control which datum is assigned to which element, replacing the default join-by-index, by computing a string identifier for each datum and element. This key function is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]); the returned string is the element’s key. The key function is then also evaluated for each new datum in *data*, being passed the current datum (*d*), the current index (*i*), and the group’s new *data*, with *this* as the group’s parent DOM element; the returned string is the datum’s key. The datum for a given key is assigned to the element with the matching key. If multiple elements have the same key, the duplicate elements are put into the exit selection; if multiple data have the same key, the duplicate data are put into the enter selection.
+
+For example, given this document:
+
+```html
+<div id="Ford"></div>
+<div id="Jarrah"></div>
+<div id="Kwon"></div>
+<div id="Locke"></div>
+<div id="Reyes"></div>
+<div id="Shephard"></div>
+```
+
+You could join data by key as follows:
+
+
+```js
+const data = [
+  {name: "Locke", number: 4},
+  {name: "Reyes", number: 8},
+  {name: "Ford", number: 15},
+  {name: "Jarrah", number: 16},
+  {name: "Shephard", number: 23},
+  {name: "Kwon", number: 42}
+];
+
+d3.selectAll("div")
+  .data(data, function(d) { return d ? d.name : this.id; })
+    .text(d => d.number);
+```
+
+This example key function uses the datum *d* if present, and otherwise falls back to the element’s id property. Since these elements were not previously bound to data, the datum *d* is null when the key function is evaluated on selected elements, and non-null when the key function is evaluated on the new data.
+
+The *update* and *enter* selections are returned in data order, while the *exit* selection preserves the selection order prior to the join. If a key function is specified, the order of elements in the selection may not match their order in the document; use [*selection*.order](#selection_order) or [*selection*.sort](#selection_sort) as needed. For more on how the key function affects the join, see [A Bar Chart, Part 2](http://bost.ocks.org/mike/bar/2/) and [Object Constancy](http://bost.ocks.org/mike/constancy/).
+
+If *data* is not specified, this method returns the array of data for the selected elements.
+
+This method cannot be used to clear bound data; use [*selection*.datum](#selection_datum) instead.
+
+<a name="selection_join" href="#selection_join">#</a> <i>selection</i>.<b>join</b>(<i>enter</i>[, <i>update</i>][, <i>exit</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/join.js)
+
+Appends, removes and reorders elements as necessary to match the data that was previously bound by [*selection*.data](#selection_data), returning the [merged](#selection_merge) enter and update selection. This method is a convenient alternative to the explicit [general update pattern](https://bl.ocks.org/mbostock/3808218), replacing [*selection*.enter](#selection_enter), [*selection*.exit](#selection_exit), [*selection*.append](#selection_append), [*selection*.remove](#selection_remove), and [*selection*.order](#selection_order). For example:
+
+```js
+svg.selectAll("circle")
+  .data(data)
+  .join("circle")
+    .attr("fill", "none")
+    .attr("stroke", "black");
+```
+
+The *enter* function may be specified as a string shorthand, as above, which is equivalent to [*selection*.append](#selection_append) with the given element name. Likewise, optional *update* and *exit* functions may be specified, which default to the identity function and calling [*selection*.remove](#selection_remove), respectively. The shorthand above is thus equivalent to:
+
+```js
+svg.selectAll("circle")
+  .data(data)
+  .join(
+    enter => enter.append("circle"),
+    update => update,
+    exit => exit.remove()
+  )
+    .attr("fill", "none")
+    .attr("stroke", "black");
+````
+
+By passing separate functions on enter, update and exit, you have greater control over what happens. And by specifying a key function to [*selection*.data](#selection_data), you can minimize changes to the DOM to optimize performance. For example, to set different fill colors for enter and update:
+
+```js
+svg.selectAll("circle")
+  .data(data)
+  .join(
+    enter => enter.append("circle").attr("fill", "green"),
+    update => update.attr("fill", "blue")
+  )
+    .attr("stroke", "black");
+```
+
+The selections returned by the *enter* and *update* functions are merged and then returned by *selection*.join.
+
+You also animate enter, update and exit by creating transitions inside the *enter*, *update* and *exit* functions. To avoid breaking the method chain, use *selection*.call to create transitions, or return an undefined enter or update selection to prevent merging: the return value of the *enter* and *update* functions specifies the two selections to merge and return by *selection*.join.
+
+For more, see the [*selection*.join notebook](https://observablehq.com/@d3/selection-join).
+
+<a name="selection_enter" href="#selection_enter">#</a> <i>selection</i>.<b>enter</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/enter.js)
+
+Returns the enter selection: placeholder nodes for each datum that had no corresponding DOM element in the selection. (The enter selection is empty for selections not returned by [*selection*.data](#selection_data).)
+
+The enter selection is typically used to create “missing” elements corresponding to new data. For example, to create DIV elements from an array of numbers:
+
+```js
+const div = d3.select("body")
+  .selectAll("div")
+  .data([4, 8, 15, 16, 23, 42])
+  .enter().append("div")
+    .text(d => d);
+```
+
+If the body is initially empty, the above code will create six new DIV elements, append them to the body in-order, and assign their text content as the associated (string-coerced) number:
+
+```html
+<div>4</div>
+<div>8</div>
+<div>15</div>
+<div>16</div>
+<div>23</div>
+<div>42</div>
+```
+
+Conceptually, the enter selection’s placeholders are pointers to the parent element (in this example, the document body). The enter selection is typically only used transiently to append elements, and is often [merged](#selection_merge) with the update selection after appending, such that modifications can be applied to both entering and updating elements.
+
+<a name="selection_exit" href="#selection_exit">#</a> <i>selection</i>.<b>exit</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/exit.js)
+
+Returns the exit selection: existing DOM elements in the selection for which no new datum was found. (The exit selection is empty for selections not returned by [*selection*.data](#selection_data).)
+
+The exit selection is typically used to remove “superfluous” elements corresponding to old data. For example, to update the DIV elements created previously with a new array of numbers:
+
+```js
+div = div.data([1, 2, 4, 8, 16, 32], d => d);
+```
+
+Since a key function was specified (as the identity function), and the new data contains the numbers [4, 8, 16] which match existing elements in the document, the update selection contains three DIV elements. Leaving those elements as-is, we can append new elements for [1, 2, 32] using the enter selection:
+
+```js
+div.enter().append("div").text(d => d);
+```
+
+Likewise, to remove the exiting elements [15, 23, 42]:
+
+```js
+div.exit().remove();
+```
+
+Now the document body looks like this:
+
+```html
+<div>1</div>
+<div>2</div>
+<div>4</div>
+<div>8</div>
+<div>16</div>
+<div>32</div>
+```
+
+The order of the DOM elements matches the order of the data because the old data’s order and the new data’s order were consistent. If the new data’s order is different, use [*selection*.order](#selection_order) to reorder the elements in the DOM. See the [General Update Pattern](http://bl.ocks.org/mbostock/3808218) example thread for more on data joins.
+
+<a name="selection_datum" href="#selection_datum">#</a> <i>selection</i>.<b>datum</b>([<i>value</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/datum.js)
+
+Gets or sets the bound data for each selected element. Unlike [*selection*.data](#selection_data), this method does not compute a join and does not affect indexes or the enter and exit selections.
+
+If a *value* is specified, sets the element’s bound data to the specified value on all selected elements. If the *value* is a constant, all elements are given the same datum; otherwise, if the *value* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). The function is then used to set each element’s new data. A null value will delete the bound data.
+
+If a *value* is not specified, returns the bound datum for the first (non-null) element in the selection. This is generally useful only if you know the selection contains exactly one element.
+
+This method is useful for accessing HTML5 [custom data attributes](http://www.w3.org/TR/html5/dom.html#custom-data-attribute). For example, given the following elements:
+
+```html
+<ul id="list">
+  <li data-username="shawnbot">Shawn Allen</li>
+  <li data-username="mbostock">Mike Bostock</li>
+</ul>
+```
+
+You can expose the custom data attributes by setting each element’s data as the built-in [dataset](http://www.w3.org/TR/html5/dom.html#dom-dataset) property:
+
+```js
+selection.datum(function() { return this.dataset; })
+```
+
+### Handling Events
+
+For interaction, selections allow listening for and dispatching of events.
+
+<a name="selection_on" href="#selection_on">#</a> <i>selection</i>.<b>on</b>(<i>typenames</i>[, <i>listener</i>[, <i>options</i>]]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/on.js)
+
+Adds or removes a *listener* to each selected element for the specified event *typenames*. The *typenames* is a string event type, such as `click`, `mouseover`, or `submit`; any [DOM event type](https://developer.mozilla.org/en-US/docs/Web/Events#Standard_events) supported by your browser may be used. The type may be optionally followed by a period (`.`) and a name; the optional name allows multiple callbacks to be registered to receive events of the same type, such as `click.foo` and `click.bar`. To specify multiple typenames, separate typenames with spaces, such as `input change` or `click.foo click.bar`.
+
+When a specified event is dispatched on a selected element, the specified *listener* will be evaluated for the element, being passed the current event (*event*) and the current datum (*d*), with *this* as the current DOM element (*event*.currentTarget). Listeners always see the latest datum for their element. Note: while you can use [*event*.pageX](https://developer.mozilla.org/en/DOM/event.pageX) and [*event*.pageY](https://developer.mozilla.org/en/DOM/event.pageY) directly, it is often convenient to transform the event position to the local coordinate system of the element that received the event using [d3.pointer](#pointer).
+
+If an event listener was previously registered for the same *typename* on a selected element, the old listener is removed before the new listener is added. To remove a listener, pass null as the *listener*. To remove all listeners for a given name, pass null as the *listener* and `.foo` as the *typename*, where `foo` is the name; to remove all listeners with no name, specify `.` as the *typename*.
+
+An optional *options* object may specify characteristics about the event listener, such as whether it is capturing or passive; see [*element*.addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).
+
+If a *listener* is not specified, returns the currently-assigned listener for the specified event *typename* on the first (non-null) selected element, if any. If multiple typenames are specified, the first matching listener is returned.
+
+<a name="selection_dispatch" href="#selection_dispatch">#</a> <i>selection</i>.<b>dispatch</b>(<i>type</i>[, <i>parameters</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/dispatch.js)
+
+Dispatches a [custom event](http://www.w3.org/TR/dom/#interface-customevent) of the specified *type* to each selected element, in order. An optional *parameters* map may be specified to set additional properties of the event. It may contain the following fields:
+
+* [`bubbles`](https://www.w3.org/TR/dom/#dom-event-bubbles) - if true, the event is dispatched to ancestors in reverse tree order.
+* [`cancelable`](https://www.w3.org/TR/dom/#dom-event-cancelable) - if true, *event*.preventDefault is allowed.
+* [`detail`](https://www.w3.org/TR/dom/#dom-customevent-detail) - any custom data associated with the event.
+
+If *parameters* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). It must return the parameters map for the current element.
+
+<a name="pointer" href="#pointer">#</a> d3.<b>pointer</b>(<i>event</i>[, <i>target</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/pointer.js)
+
+Returns a two-element array of numbers [*x*, *y*] representing the coordinates of the specified *event* relative to the specified *target*. *event* can be a [UIEvent](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent) (MouseEvent or TouchEvent), a [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent), a custom event holding a UIEvent as *event*.sourceEvent, or a [touch](https://www.w3.org/TR/touch-events/#touch-interface).
+
+If *target* is not specified, it defaults to the source event’s currentTarget property, if available.
+
+If the *target* is an SVG element, the event’s coordinates are transformed using the [inverse](https://www.w3.org/TR/geometry-1/#dom-dommatrixreadonly-inverse) of the [screen coordinate transformation matrix](https://www.w3.org/TR/SVG/types.html#__svg__SVGGraphicsElement__getScreenCTM).
+
+If the *target* is an HTML element, the event’s coordinates are translated relative to the top-left corner of the *target*’s [bounding client rectangle](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect). (As such, the coordinate system can only be translated relative to the client coordinates. See also [GeometryUtils](https://www.w3.org/TR/cssom-view-1/#the-geometryutils-interface).)
+
+Otherwise, [*event*.pageX, *event*.pageY] is returned.
+
+In the case of touch events, the coordinates of the first touch are returned. To handle multitouch interactions, see [pointers](#pointers) instead.
+
+<a name="pointers" href="#pointers">#</a> d3.<b>pointers</b>(<i>event</i>[, <i>target</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/pointers.js)
+
+Returns an array [[*x0*, *y0*], [*x1*, *y1*]…] of coordinates of the specified *event*’s pointer locations relative to the specified *target*. For mouse, stylus or single touch events, [*x0*, *y0*] is equivalent to d3.pointer(event, target). In the case of multi-touch events, the returned array contains a pair of coordinates for each of the touches.
+
+If *target* is not specified, it defaults to the source event’s currentTarget property, if available.
+
+### Control Flow
+
+For advanced usage, selections provide methods for custom control flow.
+
+<a name="selection_each" href="#selection_each">#</a> <i>selection</i>.<b>each</b>(<i>function</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/each.js)
+
+Invokes the specified *function* for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). This method can be used to invoke arbitrary code for each selected element, and is useful for creating a context to access parent and child data simultaneously, such as:
+
+```js
+parent.each(function(p, j) {
+  d3.select(this)
+    .selectAll(".child")
+      .text(d => `child ${d.name} of ${p.name}`);
+});
+```
+
+See [Sized Donut Multiples](http://bl.ocks.org/mbostock/4c5fad723c87d2fd8273) for an example.
+
+<a name="selection_call" href="#selection_call">#</a> <i>selection</i>.<b>call</b>(<i>function</i>[, <i>arguments…</i>]) · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/call.js)
+
+Invokes the specified *function* exactly once, passing in this selection along with any optional *arguments*. Returns this selection. This is equivalent to invoking the function by hand but facilitates method chaining. For example, to set several styles in a reusable function:
+
+```js
+function name(selection, first, last) {
+  selection
+      .attr("first-name", first)
+      .attr("last-name", last);
+}
+```
+
+Now say:
+
+```js
+d3.selectAll("div").call(name, "John", "Snow");
+```
+
+This is roughly equivalent to:
+
+```js
+name(d3.selectAll("div"), "John", "Snow");
+```
+
+The only difference is that *selection*.call always returns the *selection* and not the return value of the called *function*, `name`.
+
+<a name="selection_empty" href="#selection_empty">#</a> <i>selection</i>.<b>empty</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/empty.js)
+
+Returns true if this selection contains no (non-null) elements.
+
+<a name="selection_nodes" href="#selection_nodes">#</a> <i>selection</i>.<b>nodes</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/nodes.js)
+
+Returns an array of all (non-null) elements in this selection. Equivalent to:
+
+```js
+const elements = Array.from(selection);
+````
+
+See also [*selection*[Symbol.iterator]](#selection_iterator).
+
+<a name="selection_node" href="#selection_node">#</a> <i>selection</i>.<b>node</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/node.js)
+
+Returns the first (non-null) element in this selection. If the selection is empty, returns null.
+
+<a name="selection_size" href="#selection_size">#</a> <i>selection</i>.<b>size</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/size.js)
+
+Returns the total number of (non-null) elements in this selection.
+
+<a name="selection_iterator" href="#selection_iterator">#</a> <i>selection</i>[<b>Symbol.iterator</b>]() · [Source](https://github.com/d3/d3-selection/blob/master/src/selection/iterator.js)
+
+Returns an iterator over the selected (non-null) elements. For example, to iterate over the selected elements:
+
+```js
+for (const element of selection) {
+  console.log(element);
+}
+```
+
+To flatten the selection to an array:
+
+```js
+const elements = [...selection];
+````
+
+### Local Variables
+
+D3 locals allow you to define local state independent of data. For instance, when rendering [small multiples](http://bl.ocks.org/mbostock/e1192fe405703d8321a5187350910e08) of time-series data, you might want the same *x*-scale for all charts but distinct *y*-scales to compare the relative performance of each metric. D3 locals are scoped by DOM elements: on set, the value is stored on the given element; on get, the value is retrieved from given element or the nearest ancestor that defines it.
+
+<a name="local" href="#local">#</a> d3.<b>local</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/local.js)
+
+Declares a new local variable. For example:
+
+```js
+const foo = d3.local();
+```
+
+Like `var`, each local is a distinct symbolic reference; unlike `var`, the value of each local is also scoped by the DOM.
+
+<a name="local_set" href="#local_set">#</a> <i>local</i>.<b>set</b>(<i>node</i>, <i>value</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/local.js)
+
+Sets the value of this local on the specified *node* to the *value*, and returns the specified *value*. This is often performed using [*selection*.each](#selection_each):
+
+```js
+selection.each(function(d) { foo.set(this, d.value); });
+```
+
+If you are just setting a single variable, consider using [*selection*.property](#selection_property):
+
+```js
+selection.property(foo, d => d.value);
+```
+
+<a name="local_get" href="#local_get">#</a> <i>local</i>.<b>get</b>(<i>node</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/local.js)
+
+Returns the value of this local on the specified *node*. If the *node* does not define this local, returns the value from the nearest ancestor that defines it. Returns undefined if no ancestor defines this local.
+
+<a name="local_remove" href="#local_remove">#</a> <i>local</i>.<b>remove</b>(<i>node</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/local.js)
+
+Deletes this local’s value from the specified *node*. Returns true if the *node* defined this local prior to removal, and false otherwise. If ancestors also define this local, those definitions are unaffected, and thus [*local*.get](#local_get) will still return the inherited value.
+
+<a name="local_toString" href="#local_toString">#</a> <i>local</i>.<b>toString</b>() · [Source](https://github.com/d3/d3-selection/blob/master/src/local.js)
+
+Returns the automatically-generated identifier for this local. This is the name of the property that is used to store the local’s value on elements, and thus you can also set or get the local’s value using *element*[*local*] or by using [*selection*.property](#selection_property).
+
+### Namespaces
+
+XML namespaces are fun! Right? Fortunately you can mostly ignore them.
+
+<a name="namespace" href="#namespace">#</a> d3.<b>namespace</b>(<i>name</i>) · [Source](https://github.com/d3/d3-selection/blob/master/src/namespace.js)
+
+Qualifies the specified *name*, which may or may not have a namespace prefix. If the name contains a colon (`:`), the substring before the colon is interpreted as the namespace prefix, which must be registered in [d3.namespaces](#namespaces). Returns an object `space` and `local` attributes describing the full namespace URL and the local name. For example:
+
+```js
+d3.namespace("svg:text"); // {space: "http://www.w3.org/2000/svg", local: "text"}
+```
+
+If the name does not contain a colon, this function merely returns the input name.
+
+<a name="namespaces" href="#namespaces">#</a> d3.<b>namespaces</b> · [Source](https://github.com/d3/d3-selection/blob/master/src/namespaces.js)
+
+The map of registered namespace prefixes. The initial value is:
+
+```js
+{
+  svg: "http://www.w3.org/2000/svg",
+  xhtml: "http://www.w3.org/1999/xhtml",
+  xlink: "http://www.w3.org/1999/xlink",
+  xml: "http://www.w3.org/XML/1998/namespace",
+  xmlns: "http://www.w3.org/2000/xmlns/"
+}
+```
+
+Additional prefixes may be assigned as needed to create elements or attributes in other namespaces.

--- a/node_modules/d3-selection/package.json
+++ b/node_modules/d3-selection/package.json
@@ -1,0 +1,75 @@
+{
+  "_args": [
+    [
+      "d3-selection@2.0.0",
+      "/Users/Kelly/Downloads/edamontology/edam-browser"
+    ]
+  ],
+  "_from": "d3-selection@2.0.0",
+  "_id": "d3-selection@2.0.0",
+  "_inBundle": false,
+  "_integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+  "_location": "/d3-selection",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "d3-selection@2.0.0",
+    "name": "d3-selection",
+    "escapedName": "d3-selection",
+    "rawSpec": "2.0.0",
+    "saveSpec": null,
+    "fetchSpec": "2.0.0"
+  },
+  "_requiredBy": [
+    "/d3-drag"
+  ],
+  "_resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+  "_spec": "2.0.0",
+  "_where": "/Users/Kelly/Downloads/edamontology/edam-browser",
+  "author": {
+    "name": "Mike Bostock",
+    "url": "https://bost.ocks.org/mike"
+  },
+  "bugs": {
+    "url": "https://github.com/d3/d3-selection/issues"
+  },
+  "description": "Data-driven DOM manipulation: select elements and join them to data.",
+  "devDependencies": {
+    "eslint": "6",
+    "jsdom": "15",
+    "rollup": "1",
+    "rollup-plugin-terser": "5",
+    "tape": "4"
+  },
+  "files": [
+    "dist/**/*.js",
+    "src/**/*.js"
+  ],
+  "homepage": "https://d3js.org/d3-selection/",
+  "jsdelivr": "dist/d3-selection.min.js",
+  "keywords": [
+    "d3",
+    "d3-module",
+    "dom",
+    "selection",
+    "data-join"
+  ],
+  "license": "BSD-3-Clause",
+  "main": "dist/d3-selection.js",
+  "module": "src/index.js",
+  "name": "d3-selection",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/d3/d3-selection.git"
+  },
+  "scripts": {
+    "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../${npm_package_name}/dist/${npm_package_name}.js ${npm_package_name}.v${npm_package_version%%.*}.js && cp ../${npm_package_name}/dist/${npm_package_name}.min.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git add ${npm_package_name}.v${npm_package_version%%.*}.js ${npm_package_name}.v${npm_package_version%%.*}.min.js && git commit -m \"${npm_package_name} ${npm_package_version}\" && git push && cd - && zip -j dist/${npm_package_name}.zip -- LICENSE README.md dist/${npm_package_name}.js dist/${npm_package_name}.min.js",
+    "prepublishOnly": "rm -rf dist && yarn test",
+    "pretest": "rollup -c",
+    "test": "tape 'test/**/*-test.js' && eslint src"
+  },
+  "sideEffects": false,
+  "unpkg": "dist/d3-selection.min.js",
+  "version": "2.0.0"
+}

--- a/node_modules/d3-selection/src/array.js
+++ b/node_modules/d3-selection/src/array.js
@@ -1,0 +1,5 @@
+export default function(x) {
+  return typeof x === "object" && "length" in x
+    ? x // Array, TypedArray, NodeList, array-like
+    : Array.from(x); // Map, Set, iterable, string, or anything else
+}

--- a/node_modules/d3-selection/src/constant.js
+++ b/node_modules/d3-selection/src/constant.js
@@ -1,0 +1,5 @@
+export default function(x) {
+  return function() {
+    return x;
+  };
+}

--- a/node_modules/d3-selection/src/create.js
+++ b/node_modules/d3-selection/src/create.js
@@ -1,0 +1,6 @@
+import creator from "./creator.js";
+import select from "./select.js";
+
+export default function(name) {
+  return select(creator(name).call(document.documentElement));
+}

--- a/node_modules/d3-selection/src/creator.js
+++ b/node_modules/d3-selection/src/creator.js
@@ -1,0 +1,25 @@
+import namespace from "./namespace.js";
+import {xhtml} from "./namespaces.js";
+
+function creatorInherit(name) {
+  return function() {
+    var document = this.ownerDocument,
+        uri = this.namespaceURI;
+    return uri === xhtml && document.documentElement.namespaceURI === xhtml
+        ? document.createElement(name)
+        : document.createElementNS(uri, name);
+  };
+}
+
+function creatorFixed(fullname) {
+  return function() {
+    return this.ownerDocument.createElementNS(fullname.space, fullname.local);
+  };
+}
+
+export default function(name) {
+  var fullname = namespace(name);
+  return (fullname.local
+      ? creatorFixed
+      : creatorInherit)(fullname);
+}

--- a/node_modules/d3-selection/src/identity.js
+++ b/node_modules/d3-selection/src/identity.js
@@ -1,0 +1,3 @@
+export default function(x) {
+  return x;
+}

--- a/node_modules/d3-selection/src/index.js
+++ b/node_modules/d3-selection/src/index.js
@@ -1,0 +1,15 @@
+export {default as create} from "./create.js";
+export {default as creator} from "./creator.js";
+export {default as local} from "./local.js";
+export {default as matcher} from "./matcher.js";
+export {default as namespace} from "./namespace.js";
+export {default as namespaces} from "./namespaces.js";
+export {default as pointer} from "./pointer.js";
+export {default as pointers} from "./pointers.js";
+export {default as select} from "./select.js";
+export {default as selectAll} from "./selectAll.js";
+export {default as selection} from "./selection/index.js";
+export {default as selector} from "./selector.js";
+export {default as selectorAll} from "./selectorAll.js";
+export {styleValue as style} from "./selection/style.js";
+export {default as window} from "./window.js";

--- a/node_modules/d3-selection/src/local.js
+++ b/node_modules/d3-selection/src/local.js
@@ -1,0 +1,27 @@
+var nextId = 0;
+
+export default function local() {
+  return new Local;
+}
+
+function Local() {
+  this._ = "@" + (++nextId).toString(36);
+}
+
+Local.prototype = local.prototype = {
+  constructor: Local,
+  get: function(node) {
+    var id = this._;
+    while (!(id in node)) if (!(node = node.parentNode)) return;
+    return node[id];
+  },
+  set: function(node, value) {
+    return node[this._] = value;
+  },
+  remove: function(node) {
+    return this._ in node && delete node[this._];
+  },
+  toString: function() {
+    return this._;
+  }
+};

--- a/node_modules/d3-selection/src/matcher.js
+++ b/node_modules/d3-selection/src/matcher.js
@@ -1,0 +1,12 @@
+export default function(selector) {
+  return function() {
+    return this.matches(selector);
+  };
+}
+
+export function childMatcher(selector) {
+  return function(node) {
+    return node.matches(selector);
+  };
+}
+

--- a/node_modules/d3-selection/src/namespace.js
+++ b/node_modules/d3-selection/src/namespace.js
@@ -1,0 +1,7 @@
+import namespaces from "./namespaces.js";
+
+export default function(name) {
+  var prefix = name += "", i = prefix.indexOf(":");
+  if (i >= 0 && (prefix = name.slice(0, i)) !== "xmlns") name = name.slice(i + 1);
+  return namespaces.hasOwnProperty(prefix) ? {space: namespaces[prefix], local: name} : name; // eslint-disable-line no-prototype-builtins
+}

--- a/node_modules/d3-selection/src/namespaces.js
+++ b/node_modules/d3-selection/src/namespaces.js
@@ -1,0 +1,9 @@
+export var xhtml = "http://www.w3.org/1999/xhtml";
+
+export default {
+  svg: "http://www.w3.org/2000/svg",
+  xhtml: xhtml,
+  xlink: "http://www.w3.org/1999/xlink",
+  xml: "http://www.w3.org/XML/1998/namespace",
+  xmlns: "http://www.w3.org/2000/xmlns/"
+};

--- a/node_modules/d3-selection/src/pointer.js
+++ b/node_modules/d3-selection/src/pointer.js
@@ -1,0 +1,20 @@
+import sourceEvent from "./sourceEvent.js";
+
+export default function(event, node) {
+  event = sourceEvent(event);
+  if (node === undefined) node = event.currentTarget;
+  if (node) {
+    var svg = node.ownerSVGElement || node;
+    if (svg.createSVGPoint) {
+      var point = svg.createSVGPoint();
+      point.x = event.clientX, point.y = event.clientY;
+      point = point.matrixTransform(node.getScreenCTM().inverse());
+      return [point.x, point.y];
+    }
+    if (node.getBoundingClientRect) {
+      var rect = node.getBoundingClientRect();
+      return [event.clientX - rect.left - node.clientLeft, event.clientY - rect.top - node.clientTop];
+    }
+  }
+  return [event.pageX, event.pageY];
+}

--- a/node_modules/d3-selection/src/pointers.js
+++ b/node_modules/d3-selection/src/pointers.js
@@ -1,0 +1,11 @@
+import pointer from "./pointer.js";
+import sourceEvent from "./sourceEvent.js";
+
+export default function(events, node) {
+  if (events.target) { // i.e., instanceof Event, not TouchList or iterable
+    events = sourceEvent(events);
+    if (node === undefined) node = events.currentTarget;
+    events = events.touches || [events];
+  }
+  return Array.from(events, event => pointer(event, node));
+}

--- a/node_modules/d3-selection/src/select.js
+++ b/node_modules/d3-selection/src/select.js
@@ -1,0 +1,7 @@
+import {Selection, root} from "./selection/index.js";
+
+export default function(selector) {
+  return typeof selector === "string"
+      ? new Selection([[document.querySelector(selector)]], [document.documentElement])
+      : new Selection([[selector]], root);
+}

--- a/node_modules/d3-selection/src/selectAll.js
+++ b/node_modules/d3-selection/src/selectAll.js
@@ -1,0 +1,8 @@
+import array from "./array.js";
+import {Selection, root} from "./selection/index.js";
+
+export default function(selector) {
+  return typeof selector === "string"
+      ? new Selection([document.querySelectorAll(selector)], [document.documentElement])
+      : new Selection([selector == null ? [] : array(selector)], root);
+}

--- a/node_modules/d3-selection/src/selection/append.js
+++ b/node_modules/d3-selection/src/selection/append.js
@@ -1,0 +1,8 @@
+import creator from "../creator.js";
+
+export default function(name) {
+  var create = typeof name === "function" ? name : creator(name);
+  return this.select(function() {
+    return this.appendChild(create.apply(this, arguments));
+  });
+}

--- a/node_modules/d3-selection/src/selection/attr.js
+++ b/node_modules/d3-selection/src/selection/attr.js
@@ -1,0 +1,57 @@
+import namespace from "../namespace.js";
+
+function attrRemove(name) {
+  return function() {
+    this.removeAttribute(name);
+  };
+}
+
+function attrRemoveNS(fullname) {
+  return function() {
+    this.removeAttributeNS(fullname.space, fullname.local);
+  };
+}
+
+function attrConstant(name, value) {
+  return function() {
+    this.setAttribute(name, value);
+  };
+}
+
+function attrConstantNS(fullname, value) {
+  return function() {
+    this.setAttributeNS(fullname.space, fullname.local, value);
+  };
+}
+
+function attrFunction(name, value) {
+  return function() {
+    var v = value.apply(this, arguments);
+    if (v == null) this.removeAttribute(name);
+    else this.setAttribute(name, v);
+  };
+}
+
+function attrFunctionNS(fullname, value) {
+  return function() {
+    var v = value.apply(this, arguments);
+    if (v == null) this.removeAttributeNS(fullname.space, fullname.local);
+    else this.setAttributeNS(fullname.space, fullname.local, v);
+  };
+}
+
+export default function(name, value) {
+  var fullname = namespace(name);
+
+  if (arguments.length < 2) {
+    var node = this.node();
+    return fullname.local
+        ? node.getAttributeNS(fullname.space, fullname.local)
+        : node.getAttribute(fullname);
+  }
+
+  return this.each((value == null
+      ? (fullname.local ? attrRemoveNS : attrRemove) : (typeof value === "function"
+      ? (fullname.local ? attrFunctionNS : attrFunction)
+      : (fullname.local ? attrConstantNS : attrConstant)))(fullname, value));
+}

--- a/node_modules/d3-selection/src/selection/call.js
+++ b/node_modules/d3-selection/src/selection/call.js
@@ -1,0 +1,6 @@
+export default function() {
+  var callback = arguments[0];
+  arguments[0] = this;
+  callback.apply(null, arguments);
+  return this;
+}

--- a/node_modules/d3-selection/src/selection/classed.js
+++ b/node_modules/d3-selection/src/selection/classed.js
@@ -1,0 +1,75 @@
+function classArray(string) {
+  return string.trim().split(/^|\s+/);
+}
+
+function classList(node) {
+  return node.classList || new ClassList(node);
+}
+
+function ClassList(node) {
+  this._node = node;
+  this._names = classArray(node.getAttribute("class") || "");
+}
+
+ClassList.prototype = {
+  add: function(name) {
+    var i = this._names.indexOf(name);
+    if (i < 0) {
+      this._names.push(name);
+      this._node.setAttribute("class", this._names.join(" "));
+    }
+  },
+  remove: function(name) {
+    var i = this._names.indexOf(name);
+    if (i >= 0) {
+      this._names.splice(i, 1);
+      this._node.setAttribute("class", this._names.join(" "));
+    }
+  },
+  contains: function(name) {
+    return this._names.indexOf(name) >= 0;
+  }
+};
+
+function classedAdd(node, names) {
+  var list = classList(node), i = -1, n = names.length;
+  while (++i < n) list.add(names[i]);
+}
+
+function classedRemove(node, names) {
+  var list = classList(node), i = -1, n = names.length;
+  while (++i < n) list.remove(names[i]);
+}
+
+function classedTrue(names) {
+  return function() {
+    classedAdd(this, names);
+  };
+}
+
+function classedFalse(names) {
+  return function() {
+    classedRemove(this, names);
+  };
+}
+
+function classedFunction(names, value) {
+  return function() {
+    (value.apply(this, arguments) ? classedAdd : classedRemove)(this, names);
+  };
+}
+
+export default function(name, value) {
+  var names = classArray(name + "");
+
+  if (arguments.length < 2) {
+    var list = classList(this.node()), i = -1, n = names.length;
+    while (++i < n) if (!list.contains(names[i])) return false;
+    return true;
+  }
+
+  return this.each((typeof value === "function"
+      ? classedFunction : value
+      ? classedTrue
+      : classedFalse)(names, value));
+}

--- a/node_modules/d3-selection/src/selection/clone.js
+++ b/node_modules/d3-selection/src/selection/clone.js
@@ -1,0 +1,13 @@
+function selection_cloneShallow() {
+  var clone = this.cloneNode(false), parent = this.parentNode;
+  return parent ? parent.insertBefore(clone, this.nextSibling) : clone;
+}
+
+function selection_cloneDeep() {
+  var clone = this.cloneNode(true), parent = this.parentNode;
+  return parent ? parent.insertBefore(clone, this.nextSibling) : clone;
+}
+
+export default function(deep) {
+  return this.select(deep ? selection_cloneDeep : selection_cloneShallow);
+}

--- a/node_modules/d3-selection/src/selection/data.js
+++ b/node_modules/d3-selection/src/selection/data.js
@@ -1,0 +1,117 @@
+import {Selection} from "./index.js";
+import {EnterNode} from "./enter.js";
+import array from "../array.js";
+import constant from "../constant.js";
+
+function bindIndex(parent, group, enter, update, exit, data) {
+  var i = 0,
+      node,
+      groupLength = group.length,
+      dataLength = data.length;
+
+  // Put any non-null nodes that fit into update.
+  // Put any null nodes into enter.
+  // Put any remaining data into enter.
+  for (; i < dataLength; ++i) {
+    if (node = group[i]) {
+      node.__data__ = data[i];
+      update[i] = node;
+    } else {
+      enter[i] = new EnterNode(parent, data[i]);
+    }
+  }
+
+  // Put any non-null nodes that don’t fit into exit.
+  for (; i < groupLength; ++i) {
+    if (node = group[i]) {
+      exit[i] = node;
+    }
+  }
+}
+
+function bindKey(parent, group, enter, update, exit, data, key) {
+  var i,
+      node,
+      nodeByKeyValue = new Map,
+      groupLength = group.length,
+      dataLength = data.length,
+      keyValues = new Array(groupLength),
+      keyValue;
+
+  // Compute the key for each node.
+  // If multiple nodes have the same key, the duplicates are added to exit.
+  for (i = 0; i < groupLength; ++i) {
+    if (node = group[i]) {
+      keyValues[i] = keyValue = key.call(node, node.__data__, i, group) + "";
+      if (nodeByKeyValue.has(keyValue)) {
+        exit[i] = node;
+      } else {
+        nodeByKeyValue.set(keyValue, node);
+      }
+    }
+  }
+
+  // Compute the key for each datum.
+  // If there a node associated with this key, join and add it to update.
+  // If there is not (or the key is a duplicate), add it to enter.
+  for (i = 0; i < dataLength; ++i) {
+    keyValue = key.call(parent, data[i], i, data) + "";
+    if (node = nodeByKeyValue.get(keyValue)) {
+      update[i] = node;
+      node.__data__ = data[i];
+      nodeByKeyValue.delete(keyValue);
+    } else {
+      enter[i] = new EnterNode(parent, data[i]);
+    }
+  }
+
+  // Add any remaining nodes that were not bound to data to exit.
+  for (i = 0; i < groupLength; ++i) {
+    if ((node = group[i]) && (nodeByKeyValue.get(keyValues[i]) === node)) {
+      exit[i] = node;
+    }
+  }
+}
+
+function datum(node) {
+  return node.__data__;
+}
+
+export default function(value, key) {
+  if (!arguments.length) return Array.from(this, datum);
+
+  var bind = key ? bindKey : bindIndex,
+      parents = this._parents,
+      groups = this._groups;
+
+  if (typeof value !== "function") value = constant(value);
+
+  for (var m = groups.length, update = new Array(m), enter = new Array(m), exit = new Array(m), j = 0; j < m; ++j) {
+    var parent = parents[j],
+        group = groups[j],
+        groupLength = group.length,
+        data = array(value.call(parent, parent && parent.__data__, j, parents)),
+        dataLength = data.length,
+        enterGroup = enter[j] = new Array(dataLength),
+        updateGroup = update[j] = new Array(dataLength),
+        exitGroup = exit[j] = new Array(groupLength);
+
+    bind(parent, group, enterGroup, updateGroup, exitGroup, data, key);
+
+    // Now connect the enter nodes to their following update node, such that
+    // appendChild can insert the materialized enter node before this node,
+    // rather than at the end of the parent node.
+    for (var i0 = 0, i1 = 0, previous, next; i0 < dataLength; ++i0) {
+      if (previous = enterGroup[i0]) {
+        if (i0 >= i1) i1 = i0 + 1;
+        while (!(next = updateGroup[i1]) && ++i1 < dataLength);
+        previous._next = next || null;
+      }
+    }
+  }
+
+  update = new Selection(update, parents);
+  update._enter = enter;
+  update._exit = exit;
+  return update;
+}

--- a/node_modules/d3-selection/src/selection/datum.js
+++ b/node_modules/d3-selection/src/selection/datum.js
@@ -1,0 +1,5 @@
+export default function(value) {
+  return arguments.length
+      ? this.property("__data__", value)
+      : this.node().__data__;
+}

--- a/node_modules/d3-selection/src/selection/dispatch.js
+++ b/node_modules/d3-selection/src/selection/dispatch.js
@@ -1,0 +1,34 @@
+import defaultView from "../window.js";
+
+function dispatchEvent(node, type, params) {
+  var window = defaultView(node),
+      event = window.CustomEvent;
+
+  if (typeof event === "function") {
+    event = new event(type, params);
+  } else {
+    event = window.document.createEvent("Event");
+    if (params) event.initEvent(type, params.bubbles, params.cancelable), event.detail = params.detail;
+    else event.initEvent(type, false, false);
+  }
+
+  node.dispatchEvent(event);
+}
+
+function dispatchConstant(type, params) {
+  return function() {
+    return dispatchEvent(this, type, params);
+  };
+}
+
+function dispatchFunction(type, params) {
+  return function() {
+    return dispatchEvent(this, type, params.apply(this, arguments));
+  };
+}
+
+export default function(type, params) {
+  return this.each((typeof params === "function"
+      ? dispatchFunction
+      : dispatchConstant)(type, params));
+}

--- a/node_modules/d3-selection/src/selection/each.js
+++ b/node_modules/d3-selection/src/selection/each.js
@@ -1,0 +1,10 @@
+export default function(callback) {
+
+  for (var groups = this._groups, j = 0, m = groups.length; j < m; ++j) {
+    for (var group = groups[j], i = 0, n = group.length, node; i < n; ++i) {
+      if (node = group[i]) callback.call(node, node.__data__, i, group);
+    }
+  }
+
+  return this;
+}

--- a/node_modules/d3-selection/src/selection/empty.js
+++ b/node_modules/d3-selection/src/selection/empty.js
@@ -1,0 +1,3 @@
+export default function() {
+  return !this.node();
+}

--- a/node_modules/d3-selection/src/selection/enter.js
+++ b/node_modules/d3-selection/src/selection/enter.js
@@ -1,0 +1,22 @@
+import sparse from "./sparse.js";
+import {Selection} from "./index.js";
+
+export default function() {
+  return new Selection(this._enter || this._groups.map(sparse), this._parents);
+}
+
+export function EnterNode(parent, datum) {
+  this.ownerDocument = parent.ownerDocument;
+  this.namespaceURI = parent.namespaceURI;
+  this._next = null;
+  this._parent = parent;
+  this.__data__ = datum;
+}
+
+EnterNode.prototype = {
+  constructor: EnterNode,
+  appendChild: function(child) { return this._parent.insertBefore(child, this._next); },
+  insertBefore: function(child, next) { return this._parent.insertBefore(child, next); },
+  querySelector: function(selector) { return this._parent.querySelector(selector); },
+  querySelectorAll: function(selector) { return this._parent.querySelectorAll(selector); }
+};

--- a/node_modules/d3-selection/src/selection/exit.js
+++ b/node_modules/d3-selection/src/selection/exit.js
@@ -1,0 +1,6 @@
+import sparse from "./sparse.js";
+import {Selection} from "./index.js";
+
+export default function() {
+  return new Selection(this._exit || this._groups.map(sparse), this._parents);
+}

--- a/node_modules/d3-selection/src/selection/filter.js
+++ b/node_modules/d3-selection/src/selection/filter.js
@@ -1,0 +1,16 @@
+import {Selection} from "./index.js";
+import matcher from "../matcher.js";
+
+export default function(match) {
+  if (typeof match !== "function") match = matcher(match);
+
+  for (var groups = this._groups, m = groups.length, subgroups = new Array(m), j = 0; j < m; ++j) {
+    for (var group = groups[j], n = group.length, subgroup = subgroups[j] = [], node, i = 0; i < n; ++i) {
+      if ((node = group[i]) && match.call(node, node.__data__, i, group)) {
+        subgroup.push(node);
+      }
+    }
+  }
+
+  return new Selection(subgroups, this._parents);
+}

--- a/node_modules/d3-selection/src/selection/html.js
+++ b/node_modules/d3-selection/src/selection/html.js
@@ -1,0 +1,25 @@
+function htmlRemove() {
+  this.innerHTML = "";
+}
+
+function htmlConstant(value) {
+  return function() {
+    this.innerHTML = value;
+  };
+}
+
+function htmlFunction(value) {
+  return function() {
+    var v = value.apply(this, arguments);
+    this.innerHTML = v == null ? "" : v;
+  };
+}
+
+export default function(value) {
+  return arguments.length
+      ? this.each(value == null
+          ? htmlRemove : (typeof value === "function"
+          ? htmlFunction
+          : htmlConstant)(value))
+      : this.node().innerHTML;
+}

--- a/node_modules/d3-selection/src/selection/index.js
+++ b/node_modules/d3-selection/src/selection/index.js
@@ -1,0 +1,90 @@
+import selection_select from "./select.js";
+import selection_selectAll from "./selectAll.js";
+import selection_selectChild from "./selectChild.js";
+import selection_selectChildren from "./selectChildren.js";
+import selection_filter from "./filter.js";
+import selection_data from "./data.js";
+import selection_enter from "./enter.js";
+import selection_exit from "./exit.js";
+import selection_join from "./join.js";
+import selection_merge from "./merge.js";
+import selection_order from "./order.js";
+import selection_sort from "./sort.js";
+import selection_call from "./call.js";
+import selection_nodes from "./nodes.js";
+import selection_node from "./node.js";
+import selection_size from "./size.js";
+import selection_empty from "./empty.js";
+import selection_each from "./each.js";
+import selection_attr from "./attr.js";
+import selection_style from "./style.js";
+import selection_property from "./property.js";
+import selection_classed from "./classed.js";
+import selection_text from "./text.js";
+import selection_html from "./html.js";
+import selection_raise from "./raise.js";
+import selection_lower from "./lower.js";
+import selection_append from "./append.js";
+import selection_insert from "./insert.js";
+import selection_remove from "./remove.js";
+import selection_clone from "./clone.js";
+import selection_datum from "./datum.js";
+import selection_on from "./on.js";
+import selection_dispatch from "./dispatch.js";
+import selection_iterator from "./iterator.js";
+
+export var root = [null];
+
+export function Selection(groups, parents) {
+  this._groups = groups;
+  this._parents = parents;
+}
+
+function selection() {
+  return new Selection([[document.documentElement]], root);
+}
+
+function selection_selection() {
+  return this;
+}
+
+Selection.prototype = selection.prototype = {
+  constructor: Selection,
+  select: selection_select,
+  selectAll: selection_selectAll,
+  selectChild: selection_selectChild,
+  selectChildren: selection_selectChildren,
+  filter: selection_filter,
+  data: selection_data,
+  enter: selection_enter,
+  exit: selection_exit,
+  join: selection_join,
+  merge: selection_merge,
+  selection: selection_selection,
+  order: selection_order,
+  sort: selection_sort,
+  call: selection_call,
+  nodes: selection_nodes,
+  node: selection_node,
+  size: selection_size,
+  empty: selection_empty,
+  each: selection_each,
+  attr: selection_attr,
+  style: selection_style,
+  property: selection_property,
+  classed: selection_classed,
+  text: selection_text,
+  html: selection_html,
+  raise: selection_raise,
+  lower: selection_lower,
+  append: selection_append,
+  insert: selection_insert,
+  remove: selection_remove,
+  clone: selection_clone,
+  datum: selection_datum,
+  on: selection_on,
+  dispatch: selection_dispatch,
+  [Symbol.iterator]: selection_iterator
+};
+
+export default selection;

--- a/node_modules/d3-selection/src/selection/insert.js
+++ b/node_modules/d3-selection/src/selection/insert.js
@@ -1,0 +1,14 @@
+import creator from "../creator.js";
+import selector from "../selector.js";
+
+function constantNull() {
+  return null;
+}
+
+export default function(name, before) {
+  var create = typeof name === "function" ? name : creator(name),
+      select = before == null ? constantNull : typeof before === "function" ? before : selector(before);
+  return this.select(function() {
+    return this.insertBefore(create.apply(this, arguments), select.apply(this, arguments) || null);
+  });
+}

--- a/node_modules/d3-selection/src/selection/iterator.js
+++ b/node_modules/d3-selection/src/selection/iterator.js
@@ -1,0 +1,7 @@
+export default function*() {
+  for (var groups = this._groups, j = 0, m = groups.length; j < m; ++j) {
+    for (var group = groups[j], i = 0, n = group.length, node; i < n; ++i) {
+      if (node = group[i]) yield node;
+    }
+  }
+}

--- a/node_modules/d3-selection/src/selection/join.js
+++ b/node_modules/d3-selection/src/selection/join.js
@@ -1,0 +1,7 @@
+export default function(onenter, onupdate, onexit) {
+  var enter = this.enter(), update = this, exit = this.exit();
+  enter = typeof onenter === "function" ? onenter(enter) : enter.append(onenter + "");
+  if (onupdate != null) update = onupdate(update);
+  if (onexit == null) exit.remove(); else onexit(exit);
+  return enter && update ? enter.merge(update).order() : update;
+}

--- a/node_modules/d3-selection/src/selection/lower.js
+++ b/node_modules/d3-selection/src/selection/lower.js
@@ -1,0 +1,7 @@
+function lower() {
+  if (this.previousSibling) this.parentNode.insertBefore(this, this.parentNode.firstChild);
+}
+
+export default function() {
+  return this.each(lower);
+}

--- a/node_modules/d3-selection/src/selection/merge.js
+++ b/node_modules/d3-selection/src/selection/merge.js
@@ -1,0 +1,19 @@
+import {Selection} from "./index.js";
+
+export default function(selection) {
+  if (!(selection instanceof Selection)) throw new Error("invalid merge");
+
+  for (var groups0 = this._groups, groups1 = selection._groups, m0 = groups0.length, m1 = groups1.length, m = Math.min(m0, m1), merges = new Array(m0), j = 0; j < m; ++j) {
+    for (var group0 = groups0[j], group1 = groups1[j], n = group0.length, merge = merges[j] = new Array(n), node, i = 0; i < n; ++i) {
+      if (node = group0[i] || group1[i]) {
+        merge[i] = node;
+      }
+    }
+  }
+
+  for (; j < m0; ++j) {
+    merges[j] = groups0[j];
+  }
+
+  return new Selection(merges, this._parents);
+}

--- a/node_modules/d3-selection/src/selection/node.js
+++ b/node_modules/d3-selection/src/selection/node.js
@@ -1,0 +1,11 @@
+export default function() {
+
+  for (var groups = this._groups, j = 0, m = groups.length; j < m; ++j) {
+    for (var group = groups[j], i = 0, n = group.length; i < n; ++i) {
+      var node = group[i];
+      if (node) return node;
+    }
+  }
+
+  return null;
+}

--- a/node_modules/d3-selection/src/selection/nodes.js
+++ b/node_modules/d3-selection/src/selection/nodes.js
@@ -1,0 +1,3 @@
+export default function() {
+  return Array.from(this);
+}

--- a/node_modules/d3-selection/src/selection/on.js
+++ b/node_modules/d3-selection/src/selection/on.js
@@ -1,0 +1,67 @@
+function contextListener(listener) {
+  return function(event) {
+    listener.call(this, event, this.__data__);
+  };
+}
+
+function parseTypenames(typenames) {
+  return typenames.trim().split(/^|\s+/).map(function(t) {
+    var name = "", i = t.indexOf(".");
+    if (i >= 0) name = t.slice(i + 1), t = t.slice(0, i);
+    return {type: t, name: name};
+  });
+}
+
+function onRemove(typename) {
+  return function() {
+    var on = this.__on;
+    if (!on) return;
+    for (var j = 0, i = -1, m = on.length, o; j < m; ++j) {
+      if (o = on[j], (!typename.type || o.type === typename.type) && o.name === typename.name) {
+        this.removeEventListener(o.type, o.listener, o.options);
+      } else {
+        on[++i] = o;
+      }
+    }
+    if (++i) on.length = i;
+    else delete this.__on;
+  };
+}
+
+function onAdd(typename, value, options) {
+  return function() {
+    var on = this.__on, o, listener = contextListener(value);
+    if (on) for (var j = 0, m = on.length; j < m; ++j) {
+      if ((o = on[j]).type === typename.type && o.name === typename.name) {
+        this.removeEventListener(o.type, o.listener, o.options);
+        this.addEventListener(o.type, o.listener = listener, o.options = options);
+        o.value = value;
+        return;
+      }
+    }
+    this.addEventListener(typename.type, listener, options);
+    o = {type: typename.type, name: typename.name, value: value, listener: listener, options: options};
+    if (!on) this.__on = [o];
+    else on.push(o);
+  };
+}
+
+export default function(typename, value, options) {
+  var typenames = parseTypenames(typename + ""), i, n = typenames.length, t;
+
+  if (arguments.length < 2) {
+    var on = this.node().__on;
+    if (on) for (var j = 0, m = on.length, o; j < m; ++j) {
+      for (i = 0, o = on[j]; i < n; ++i) {
+        if ((t = typenames[i]).type === o.type && t.name === o.name) {
+          return o.value;
+        }
+      }
+    }
+    return;
+  }
+
+  on = value ? onAdd : onRemove;
+  for (i = 0; i < n; ++i) this.each(on(typenames[i], value, options));
+  return this;
+}

--- a/node_modules/d3-selection/src/selection/order.js
+++ b/node_modules/d3-selection/src/selection/order.js
@@ -1,0 +1,13 @@
+export default function() {
+
+  for (var groups = this._groups, j = -1, m = groups.length; ++j < m;) {
+    for (var group = groups[j], i = group.length - 1, next = group[i], node; --i >= 0;) {
+      if (node = group[i]) {
+        if (next && node.compareDocumentPosition(next) ^ 4) next.parentNode.insertBefore(node, next);
+        next = node;
+      }
+    }
+  }
+
+  return this;
+}

--- a/node_modules/d3-selection/src/selection/property.js
+++ b/node_modules/d3-selection/src/selection/property.js
@@ -1,0 +1,28 @@
+function propertyRemove(name) {
+  return function() {
+    delete this[name];
+  };
+}
+
+function propertyConstant(name, value) {
+  return function() {
+    this[name] = value;
+  };
+}
+
+function propertyFunction(name, value) {
+  return function() {
+    var v = value.apply(this, arguments);
+    if (v == null) delete this[name];
+    else this[name] = v;
+  };
+}
+
+export default function(name, value) {
+  return arguments.length > 1
+      ? this.each((value == null
+          ? propertyRemove : typeof value === "function"
+          ? propertyFunction
+          : propertyConstant)(name, value))
+      : this.node()[name];
+}

--- a/node_modules/d3-selection/src/selection/raise.js
+++ b/node_modules/d3-selection/src/selection/raise.js
@@ -1,0 +1,7 @@
+function raise() {
+  if (this.nextSibling) this.parentNode.appendChild(this);
+}
+
+export default function() {
+  return this.each(raise);
+}

--- a/node_modules/d3-selection/src/selection/remove.js
+++ b/node_modules/d3-selection/src/selection/remove.js
@@ -1,0 +1,8 @@
+function remove() {
+  var parent = this.parentNode;
+  if (parent) parent.removeChild(this);
+}
+
+export default function() {
+  return this.each(remove);
+}

--- a/node_modules/d3-selection/src/selection/select.js
+++ b/node_modules/d3-selection/src/selection/select.js
@@ -1,0 +1,17 @@
+import {Selection} from "./index.js";
+import selector from "../selector.js";
+
+export default function(select) {
+  if (typeof select !== "function") select = selector(select);
+
+  for (var groups = this._groups, m = groups.length, subgroups = new Array(m), j = 0; j < m; ++j) {
+    for (var group = groups[j], n = group.length, subgroup = subgroups[j] = new Array(n), node, subnode, i = 0; i < n; ++i) {
+      if ((node = group[i]) && (subnode = select.call(node, node.__data__, i, group))) {
+        if ("__data__" in node) subnode.__data__ = node.__data__;
+        subgroup[i] = subnode;
+      }
+    }
+  }
+
+  return new Selection(subgroups, this._parents);
+}

--- a/node_modules/d3-selection/src/selection/selectAll.js
+++ b/node_modules/d3-selection/src/selection/selectAll.js
@@ -1,0 +1,26 @@
+import {Selection} from "./index.js";
+import array from "../array.js";
+import selectorAll from "../selectorAll.js";
+
+function arrayAll(select) {
+  return function() {
+    var group = select.apply(this, arguments);
+    return group == null ? [] : array(group);
+  };
+}
+
+export default function(select) {
+  if (typeof select === "function") select = arrayAll(select);
+  else select = selectorAll(select);
+
+  for (var groups = this._groups, m = groups.length, subgroups = [], parents = [], j = 0; j < m; ++j) {
+    for (var group = groups[j], n = group.length, node, i = 0; i < n; ++i) {
+      if (node = group[i]) {
+        subgroups.push(select.call(node, node.__data__, i, group));
+        parents.push(node);
+      }
+    }
+  }
+
+  return new Selection(subgroups, parents);
+}

--- a/node_modules/d3-selection/src/selection/selectChild.js
+++ b/node_modules/d3-selection/src/selection/selectChild.js
@@ -1,0 +1,18 @@
+import {childMatcher} from "../matcher.js";
+
+var find = Array.prototype.find;
+
+function childFind(match) {
+  return function() {
+    return find.call(this.children, match);
+  };
+}
+
+function childFirst() {
+  return this.firstElementChild;
+}
+
+export default function(match) {
+  return this.select(match == null ? childFirst
+      : childFind(typeof match === "function" ? match : childMatcher(match)));
+}

--- a/node_modules/d3-selection/src/selection/selectChildren.js
+++ b/node_modules/d3-selection/src/selection/selectChildren.js
@@ -1,0 +1,18 @@
+import {childMatcher} from "../matcher.js";
+
+var filter = Array.prototype.filter;
+
+function children() {
+  return this.children;
+}
+
+function childrenFilter(match) {
+  return function() {
+    return filter.call(this.children, match);
+  };
+}
+
+export default function(match) {
+  return this.selectAll(match == null ? children
+      : childrenFilter(typeof match === "function" ? match : childMatcher(match)));
+}

--- a/node_modules/d3-selection/src/selection/size.js
+++ b/node_modules/d3-selection/src/selection/size.js
@@ -1,0 +1,5 @@
+export default function() {
+  let size = 0;
+  for (const node of this) ++size; // eslint-disable-line no-unused-vars
+  return size;
+}

--- a/node_modules/d3-selection/src/selection/sort.js
+++ b/node_modules/d3-selection/src/selection/sort.js
@@ -1,0 +1,24 @@
+import {Selection} from "./index.js";
+
+export default function(compare) {
+  if (!compare) compare = ascending;
+
+  function compareNode(a, b) {
+    return a && b ? compare(a.__data__, b.__data__) : !a - !b;
+  }
+
+  for (var groups = this._groups, m = groups.length, sortgroups = new Array(m), j = 0; j < m; ++j) {
+    for (var group = groups[j], n = group.length, sortgroup = sortgroups[j] = new Array(n), node, i = 0; i < n; ++i) {
+      if (node = group[i]) {
+        sortgroup[i] = node;
+      }
+    }
+    sortgroup.sort(compareNode);
+  }
+
+  return new Selection(sortgroups, this._parents).order();
+}
+
+function ascending(a, b) {
+  return a < b ? -1 : a > b ? 1 : a >= b ? 0 : NaN;
+}

--- a/node_modules/d3-selection/src/selection/sparse.js
+++ b/node_modules/d3-selection/src/selection/sparse.js
@@ -1,0 +1,3 @@
+export default function(update) {
+  return new Array(update.length);
+}

--- a/node_modules/d3-selection/src/selection/style.js
+++ b/node_modules/d3-selection/src/selection/style.js
@@ -1,0 +1,35 @@
+import defaultView from "../window.js";
+
+function styleRemove(name) {
+  return function() {
+    this.style.removeProperty(name);
+  };
+}
+
+function styleConstant(name, value, priority) {
+  return function() {
+    this.style.setProperty(name, value, priority);
+  };
+}
+
+function styleFunction(name, value, priority) {
+  return function() {
+    var v = value.apply(this, arguments);
+    if (v == null) this.style.removeProperty(name);
+    else this.style.setProperty(name, v, priority);
+  };
+}
+
+export default function(name, value, priority) {
+  return arguments.length > 1
+      ? this.each((value == null
+            ? styleRemove : typeof value === "function"
+            ? styleFunction
+            : styleConstant)(name, value, priority == null ? "" : priority))
+      : styleValue(this.node(), name);
+}
+
+export function styleValue(node, name) {
+  return node.style.getPropertyValue(name)
+      || defaultView(node).getComputedStyle(node, null).getPropertyValue(name);
+}

--- a/node_modules/d3-selection/src/selection/text.js
+++ b/node_modules/d3-selection/src/selection/text.js
@@ -1,0 +1,25 @@
+function textRemove() {
+  this.textContent = "";
+}
+
+function textConstant(value) {
+  return function() {
+    this.textContent = value;
+  };
+}
+
+function textFunction(value) {
+  return function() {
+    var v = value.apply(this, arguments);
+    this.textContent = v == null ? "" : v;
+  };
+}
+
+export default function(value) {
+  return arguments.length
+      ? this.each(value == null
+          ? textRemove : (typeof value === "function"
+          ? textFunction
+          : textConstant)(value))
+      : this.node().textContent;
+}

--- a/node_modules/d3-selection/src/selector.js
+++ b/node_modules/d3-selection/src/selector.js
@@ -1,0 +1,7 @@
+function none() {}
+
+export default function(selector) {
+  return selector == null ? none : function() {
+    return this.querySelector(selector);
+  };
+}

--- a/node_modules/d3-selection/src/selectorAll.js
+++ b/node_modules/d3-selection/src/selectorAll.js
@@ -1,0 +1,9 @@
+function empty() {
+  return [];
+}
+
+export default function(selector) {
+  return selector == null ? empty : function() {
+    return this.querySelectorAll(selector);
+  };
+}

--- a/node_modules/d3-selection/src/sourceEvent.js
+++ b/node_modules/d3-selection/src/sourceEvent.js
@@ -1,0 +1,5 @@
+export default function(event) {
+  let sourceEvent;
+  while (sourceEvent = event.sourceEvent) event = sourceEvent;
+  return event;
+}

--- a/node_modules/d3-selection/src/window.js
+++ b/node_modules/d3-selection/src/window.js
@@ -1,0 +1,5 @@
+export default function(node) {
+  return (node.ownerDocument && node.ownerDocument.defaultView) // node is a Node
+      || (node.document && node) // node is a Window
+      || node.defaultView; // node is a Document
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "edam-browser",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA=="
+    },
+    "d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "requires": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "jshint": "^2.9.5"
+  },
+  "dependencies": {
+    "d3-drag": "^2.0.0"
   }
 }


### PR DESCRIPTION
I've managed to update the cursor to a hand/grab cursor when hovering over the tree on the edam browser. This would allow users to know they can drag the tree. However, I'm still attempting to have the cursor change when dragging the tree @bryan-brancotte if you have any recommendations on where I can look more into this, I would greatly appreciate any help!