### PR TITLE
Changes in local run section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Go to https://edamontology.github.io/edam-browser/
 
 ### ... locally
 
-Download/clone the repository
+1. Download/clone the repository
 
-Run `start_edam_stand_alone_browser.sh`
+2. Change to working directory : `cd edam-browser`
 
-It starts a web server allowing you to browse EDAM on [localhost:20080](http://0.0.0.0:20080).
+3. Run the command : `./start_edam_stand_alone_browser.sh`
+
+    It starts a web server allowing you to browse EDAM on [localhost:20080](http://0.0.0.0:20080).
 
 ### ... with a custom ontology
 


### PR DESCRIPTION
In the local run section of README file the command to run was given start_edam_stand_alone_browser.sh . But I think giving complete command would be useful : `./start_edam_stand_alone_browser.sh'. Also provided the bullet points to the steps to follow.