### PR TITLE
Adding border colour for header in Dark-theme

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -73,7 +73,6 @@
 
 .dark-mode #page-header {
   background-color: #080808;
-  color: #B8B8B8;
   border-bottom: none !important;
 }
 

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -72,8 +72,7 @@
 }
 
 .dark-mode #page-header {
-  background-color: #080808;
-  border-bottom: none !important;
+  border-bottom-color: #252525;
 }
 
 .dark-mode .panel-heading {

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -71,6 +71,12 @@
   border-color: #050505;
 }
 
+.dark-mode #page-header {
+  background-color: #080808;
+  color: #B8B8B8;
+  border-bottom: none !important;
+}
+
 .dark-mode .panel-heading {
   background-color: #111111;
   color: #B8B8B8;


### PR DESCRIPTION
Minor Fix.
<!--
Thank you for your pull request! If you haven't, do not forget to read https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md 
As a reminder here is a checklist
-->

### Checklist

- [X] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [X] I only changed lines related to my PR (no bulk reformating)
- [X] I indicated the source and check the license if I re-use code, or I did not re-use code
- [X] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.
### Details
<!-- Put any relevant information below, or remove Details section -->
Before:
![Screenshot from 2021-04-28 14-00-38](https://user-images.githubusercontent.com/45493793/116372660-4682c480-a82a-11eb-9376-d2f0d02d6667.png)
After:
![Screenshot from 2021-04-28 13-56-53](https://user-images.githubusercontent.com/45493793/116372796-69ad7400-a82a-11eb-8462-2be0155cb10a.png)
Check for the bottom-border for the header. 
Reverted the changes done in #143, cause earlier I wasn't so clear what you're trying to do so adjusted this thing according to your commits @bryan-brancotte 
Now since that's merged so this's needed. 