### PR TITLE
Added styling for tooltip (term-details table) in dark mode

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -219,18 +219,18 @@ div.btn-toggle-wrapper {
   border-color: #050505;
 }
 
-.dark-mode .popover {
+.dark-mode .popover, .tooltip .panel-body {
   background-color: #303030;
   color: black;
 }
 
-.dark-mode .popover td {
+.dark-mode .popover td, .tooltip .list-unstyled li , .tooltip .panel-body tbody td, .tooltip .panel-body tbody th {
   background-color: #404040;
   color: white;
   border-color: #282828;
 }
 
-.dark-mode .popover tr {
+.dark-mode .popover tr, .tooltip .panel-body tbody tr {
   border-width: 1px;
 }
 


### PR DESCRIPTION
### Checklist

- [x] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] I only changed lines related to my PR (no bulk reformatting)
- [x] I indicated the source and check the license if I re-use code, or I did not re-use code
- [x] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.


### Details
Before:
![Screenshot from 2021-05-13 03-14-11](https://user-images.githubusercontent.com/45493793/118048178-881e7e00-b399-11eb-9c16-8c2630f739c2.png)
After:
![Screenshot from 2021-05-13 03-14-21](https://user-images.githubusercontent.com/45493793/118048198-9076b900-b399-11eb-8171-2411e3d86be7.png)
@bryan-brancotte 
