### PR TITLE
prevent selection when dragging and resizing tree

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -214,6 +214,9 @@ body {
 .temp:last-child {
     opacity: 0;
 }
+.d3js-tree-container>svg{
+    use-select:none;
+}
 @media (max-width: 768px){
     #page-header>*:last-child{
         min-width:90vw;

--- a/css/index.css
+++ b/css/index.css
@@ -214,13 +214,6 @@ body {
 .temp:last-child {
     opacity: 0;
 }
-.tree-controls:hover {
-    user-select: auto;
-}
-.tree-controls,
-.d3js-tree-container>svg{
-    user-select:none;
-}
 @media (max-width: 768px){
     #page-header>*:last-child{
         min-width:90vw;
@@ -238,5 +231,8 @@ body {
 }
 .flex-column{
     flex-direction: column;
+}
+.user-select-none{
+    user-select:none;
 }
 /*end of file*/

--- a/css/index.css
+++ b/css/index.css
@@ -214,8 +214,12 @@ body {
 .temp:last-child {
     opacity: 0;
 }
+.tree-controls:hover {
+    user-select: auto;
+}
+.tree-controls,
 .d3js-tree-container>svg{
-    use-select:none;
+    user-select:none;
 }
 @media (max-width: 768px){
     #page-header>*:last-child{

--- a/js/index.js
+++ b/js/index.js
@@ -77,6 +77,7 @@ window.onload = function() {
         );
         document.documentElement.addEventListener("mousemove", doDrag, false);
         document.documentElement.addEventListener("mouseup", stopDrag, false);
+        document.getElementsByTagName("body")[0].classList.add("user-select-none");
     }
     function doDrag(e) {
         treeElement.style.height = startHeight + e.clientY - startY + "px";
@@ -85,6 +86,7 @@ window.onload = function() {
         document.documentElement.removeEventListener("mousemove", doDrag, false);
         document.documentElement.removeEventListener("mouseup", stopDrag, false);
         localStorage.setItem("tree-and-controls-height", treeElement.style.height);
+        document.getElementsByTagName("body")[0].classList.remove("user-select-none");
     }
     $("input[name='show-detail']").prop("checked" , (localStorage.getItem("show-detail")||"true") == "true");
     $("input[name='show-community-usage']").prop("checked" , (localStorage.getItem("show-community-usage")||"false") == "true");


### PR DESCRIPTION
Closes #200

<!--
Thank you for your pull request! If you haven't, do not forget to read https://github.com/edamontology/edam-browser/blob/main/CONTRIBUTING.md 
As a reminder here is a checklist
-->

### Checklist
<!-- To tick an item in the checklist simply replace [ ] with [x]. You can also tick them later once the PR is submitted.. -->

- [x] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] I only changed lines related to my PR (no bulk reformatting)
- [x] I indicated the source and check the license if I re-use code, or I did not re-use code
- [x] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.

### Issue

Closes #200
<!-- pick one of close/fix/resolve, remove the other and then replace ??? with the issue number -->

### Details

I am wondering if the selectability of text is used somewhere, but I don't think so.
