### PR TITLE
Don't show the resizer when not using an accurate pointing device.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -137,7 +137,12 @@ a:before {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
 }
-
+@media (pointer: none),
+       (pointer: coarse) {
+    .resizer{
+        display:None
+    }
+}
 .tree-controls{
     position: absolute ;
     display:flex;


### PR DESCRIPTION
### Checklist
<!-- To tick an item in the checklist simply replace [ ] with [x]. You can also tick them later once the PR is submitted.. -->

- [x] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] I only changed lines related to my PR (no bulk reformatting)
- [x] I indicated the source and check the license if I re-use code, or I did not re-use code
- [x] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.

### Issue

resolve #201


### Details

source : 

https://ferie.medium.com/detect-a-touch-device-with-only-css-9f8e30fa1134

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer