### PR TITLE
fix(tree): Fix conflicting events when doublclicking nodes

### DIFF
--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -178,7 +178,6 @@ function interactive_tree() {
                         d3.event.stopPropagation();
                     })
                     .on("click", function(d,i) { handleClick(d);});
-                    
 
                 nodeEnter.append("svg:text")
                     .text(textAccessor)

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -173,7 +173,13 @@ function interactive_tree() {
                     .attr("transform", function(d) {
                         return "translate(" + (source.y0 || source.y) + "," + (source.x0 || source.x) + ")";
                     })
-                    .on("click", function(d,i) { handleClick(d);});
+                    .on("click", function(d,i) {
+                         handleClick(d);})
+                    .on("dblclick", () => {
+                        //stop doubleclick zoom effect
+                        d3.event.stopPropagation();
+                    });
+                    
 
                 nodeEnter.append("svg:text")
                     .text(textAccessor)
@@ -351,7 +357,7 @@ function interactive_tree() {
                 //adding ?
                 attemptToSelectElement(d);
             }
-        }else if (!d3.event.shiftKey && !d3.event.ctrlKey && !d3.event.altKey){
+        }else if (!d3.event.shiftKey && !d3.event.ctrlKey && !d3.event.altKey && d3.event.detail == 1){
             chart.cmd.clearSelectedElements(false);
             toggle(d);
             clickedElementHandler(d);

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -173,11 +173,11 @@ function interactive_tree() {
                     .attr("transform", function(d) {
                         return "translate(" + (source.y0 || source.y) + "," + (source.x0 || source.x) + ")";
                     })
-                    .on("click", function(d,i) { handleClick(d);})
                     .on("dblclick", () => {
                         //stop doubleclick zoom effect
                         d3.event.stopPropagation();
-                    });
+                    })
+                    .on("click", function(d,i) { handleClick(d);});
                     
 
                 nodeEnter.append("svg:text")

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -173,8 +173,7 @@ function interactive_tree() {
                     .attr("transform", function(d) {
                         return "translate(" + (source.y0 || source.y) + "," + (source.x0 || source.x) + ")";
                     })
-                    .on("click", function(d,i) {
-                         handleClick(d);})
+                    .on("click", function(d,i) { handleClick(d);})
                     .on("dblclick", () => {
                         //stop doubleclick zoom effect
                         d3.event.stopPropagation();


### PR DESCRIPTION

### Checklist


- [x] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] I only changed lines related to my PR (no bulk reformatting)
- [x] I indicated the source and check the license if I re-use code, or I did not re-use code
- [x] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.

### Issue

closes #117 



### Details

doubleClick zoom is still (partially) triggered (Omics first click for example). But the toggle effect is fixed.


![treeconflictingsolution](https://user-images.githubusercontent.com/37930475/120166764-3da45a80-c1fd-11eb-9660-2bf273983870.gif)

