### PR TITLE
animate the transition when moving elements into view

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -223,7 +223,7 @@ body {
 svg{
     transition: box-shadow 0.1s ease-in-out;
 }
-.dragged-or-moved{
+.dragged-or-moved:not(.auto-drag){
     box-shadow: inset 0 0 0.2em 0.2em #6666;
     cursor: grabbing;
 }

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -82,7 +82,9 @@ function interactive_tree() {
                     var currentTransform=vis.attr("transform")||'';
                     currentTransform=currentTransform.replace("(1)","(1.0000000)");
                     if (currentTransform.includes((d3.zoomTransform(svg.node()).k.toString()+".0000000").substring(0,6)))
-                        svg.node().classList.add("dragged-or-moved");
+                        if (!svg.node().classList.contains("auto-drag"))
+                            svg.node().classList.add("dragged-or-moved");
+                        console.log(svg.node().classList);
                     vis.attr("transform", d3.event.transform);
                 })
                 .on("end", function () {
@@ -147,9 +149,13 @@ function interactive_tree() {
                 y = y*scale+height/2;
 
                 var t = d3.zoomIdentity.translate(x,y).scale(scale);
-                svg.call(zoom.transform, t);
-  
-
+                svg.transition()
+                    .duration(duration)
+                    .call(zoom.transform, t)
+                    .node().classList.add("auto-drag");
+                setTimeout(function() {
+                    svg.node().classList.remove("auto-drag")
+                }, duration);
             };
 
             update = function (source) {

--- a/js/tree-reusable-d3.js
+++ b/js/tree-reusable-d3.js
@@ -84,7 +84,6 @@ function interactive_tree() {
                     if (currentTransform.includes((d3.zoomTransform(svg.node()).k.toString()+".0000000").substring(0,6)))
                         if (!svg.node().classList.contains("auto-drag"))
                             svg.node().classList.add("dragged-or-moved");
-                        console.log(svg.node().classList);
                     vis.attr("transform", d3.event.transform);
                 })
                 .on("end", function () {


### PR DESCRIPTION
I found a way to animate your moveIntoView, the catch is that It triggers the effect when we drag the tree so I had to find a hacky way to not have the effet when moving the tree with moveIntoView. 

I would like to have your opinion @HagerDakroury , and maybe idea to improve the way to prevent the effect, better than the use of `auto-drag` css class.

P.S: adding it to the project as you are a reviewer of this PR