### PR TITLE
fix(edit form): Correct github generated message

### DIFF
--- a/js/edit.js
+++ b/js/edit.js
@@ -100,7 +100,8 @@ function addTermField(container, kind, initial_term){
 
     $(".search-term[name="+kind+"-"+i+"]")
                 .val(initial_term?initial_term.text:"")
-                .attr('data-initial',initial_term?initial_term.data.uri:"");
+                .attr('data-initial',initial_term?initial_term.data.uri:"")
+                .attr("data-selected",initial_term?initial_term.data.uri:"");
 //    build_autocomplete(
 //        getTreeFile(getCookie("edam_browser_branch","topic")),
     build_autocomplete_from_edam_browser(browser,
@@ -136,7 +137,7 @@ function sendToGitHub(){
     var ids=["#id_parent", "#id_label", "#id_definition", "#id_exactSynonyms", "#id_narrowSynonyms"];
     var i;
     for (i=0;i<$(".search-term").length;i++){
-        ids.push(".search-term[name=parent-"+i+"]");
+        ids.push(".search-term[name="+$(".search-term")[i].name+"]");
     }
     msg="";
     msg+="[//]: # (You can add comment regarding your issue hereafter)\n";

--- a/js/edit.js
+++ b/js/edit.js
@@ -136,9 +136,9 @@ window.onload = function() {
 function sendToGitHub(){
     var ids=["#id_parent", "#id_label", "#id_definition", "#id_exactSynonyms", "#id_narrowSynonyms"];
     var i;
-    for (i=0;i<$(".search-term").length;i++){
-        ids.push(".search-term[name="+$(".search-term")[i].name+"]");
-    }
+    $(".search-term").each(function(){
+        ids.push(".search-term[name="+this.getAttribute("name")+"]");
+    })
     msg="";
     msg+="[//]: # (You can add comment regarding your issue hereafter)\n";
     if ($("#id_github_comments").val()){


### PR DESCRIPTION

### Checklist

- [x] I indicated which issue (if any) is closed with this PR using [closing keywords](https://help.github.com/articles/closing-issues-using-keywords)
- [x] I only changed lines related to my PR (no bulk reformatting)
- [x] I indicated the source and check the license if I re-use code, or I did not re-use code
- [x] I made my best to solve only one issue in this PR, or explain why multi had to be solved at once.

### Issue

closes #50 
(this fixes a bug blocking the closing of this issue, but all work related to the issue itself has already been done)

<!-- pick one of close/fix/resolve, remove the other and then replace ??? with the issue number -->

### Details
<!-- Put any relevant information below, or remove Details section -->
<!-- If your PR is about a new visual effect, screenshot or screen recording are warmly welcomed, I personally recommend https://github.com/phw/peek to record as gif. -->

the bug is described in  https://github.com/edamontology/edam-browser/issues/50#issuecomment-864027843

**after the fix**

![githublow](https://user-images.githubusercontent.com/37930475/122757139-9369a100-d297-11eb-8bf6-823818fe1487.gif)

**bug details:**
1. all new terms (after the first parent) were inheriting the `data-selected` attribute from the cloned search-term. So, it was detected as a change from `data-initial` (even though the user didn't actually change any term) 
2. all new terms were named `parent-i`
